### PR TITLE
An origin state root can be reported to auxiliary

### DIFF
--- a/contracts/core/AuxiliaryCore.sol
+++ b/contracts/core/AuxiliaryCore.sol
@@ -33,7 +33,7 @@ contract AuxiliaryCore is AuxiliaryCoreInterface, AuxiliaryCoreConfig {
     /* Public Variables */
 
     /** The id of the origin chain that this core tracks. */
-    uint256 public chainIdRemote;
+    uint256 public chainIdOrigin;
 
     /**
      * Maps heights on the Ethereum blockchain to their respoctive reported
@@ -48,9 +48,9 @@ contract AuxiliaryCore is AuxiliaryCoreInterface, AuxiliaryCoreConfig {
 
     /* Constructor */
 
-    /** @param _chainIdRemote The id of the tracked Ethereum chain. */
-    constructor (uint256 _chainIdRemote) public {
-        chainIdRemote = _chainIdRemote;
+    /** @param _chainIdOrigin The id of the tracked Ethereum chain. */
+    constructor (uint256 _chainIdOrigin) public {
+        chainIdOrigin = _chainIdOrigin;
     }
 
     /* External Functions */

--- a/contracts/core/AuxiliaryCore.sol
+++ b/contracts/core/AuxiliaryCore.sol
@@ -1,0 +1,144 @@
+pragma solidity ^0.4.23;
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "./AuxiliaryCoreConfig.sol";
+import "./AuxiliaryCoreInterface.sol";
+
+/**
+ * @title AuxiliaryCore tracks an Ethereum blockchain on a proof of stake chain.
+ */
+contract AuxiliaryCore is AuxiliaryCoreInterface, AuxiliaryCoreConfig {
+
+    /* Events */
+
+    /** Emitted whenever a state root is successfully reported. */
+    event StateRootReported(
+        uint256 indexed height,
+        bytes32 indexed stateRoot
+    );
+
+    /* Public Variables */
+
+    /** The id of the origin chain that this core tracks. */
+    uint256 public chainIdRemote;
+
+    /**
+     * Maps heights on the Ethereum blockchain to their respoctive reported
+     * state root. As Ethereum can fork, multiple state roots can be reported
+     * for the same height.
+     * It is sufficient to only store the state roots of Ethereum. The Casper
+     * FFG rules will assert that only the correct state roots will be
+     * finalised. Falsely reported state roots will consume `msg.value` that
+     * won't ever be returned to the sender of the wrong state root.
+     */
+    mapping (uint256 => bytes32[]) public reportedStateRoots;
+
+    /* Constructor */
+
+    /** @param _chainIdRemote The id of the tracked Ethereum chain. */
+    constructor (uint256 _chainIdRemote) public {
+        chainIdRemote = _chainIdRemote;
+    }
+
+    /* External Functions */
+
+    /**
+     * @notice Report an Ethereum state root at a specific height. You need to
+     *         send the appropriate value with the transaction in order for the
+     *         state root to be reported.
+     *
+     * @param _height The height in the Ethereum blockchain that the state root
+     *                is reported for.
+     * @param _stateRoot The state root to report at the given height. Reverts
+     *                   if the same state root has been reported for this
+     *                   height before.
+     */
+    function reportStateRoot(
+        uint256 _height,
+        bytes32 _stateRoot
+    )
+        external
+        payable
+    {
+        require(
+            _stateRoot != bytes32(0),
+            "The state root should not be `0`."
+        );
+
+        require(
+            msg.value >= COST_REPORT_STATE_ROOT,
+            "You must send at least the required amount of value to report a state root."
+        );
+
+        require(
+            !hasBeenReported(_height, _stateRoot),
+            "The given state root has already been reported at the same height."
+        );
+        
+        reportedStateRoots[_height].push(_stateRoot);
+        emit StateRootReported(_height, _stateRoot);
+    }
+
+    /**
+     * @notice Returns all the state roots that have been reported at a given
+     *         height.
+     *
+     * @param _height The height for which to get the reported state roots.
+     *
+     * @return The state roots that have been reported at the given height.
+     */
+    function getReportedStateRoots(
+        uint256 _height
+    )
+        external
+        view
+        returns (bytes32[])
+    {
+        return reportedStateRoots[_height];
+    }
+
+    /* Private Functions */
+
+    /**
+     * @notice Checks whether a state root is already recorded at a given
+     *         height of the origin blockchain.
+     *
+     * @dev Iterates over all recorded state roots and returns true when one is
+     *      equal to the state root that is given.
+     *
+     * @param _height The height for which to check.
+     * @param _stateRoot The state root to chekc for.
+     *
+     * @return `true` if the state root is already recorded at the given
+     *         height.
+     */
+    function hasBeenReported(
+        uint256 _height,
+        bytes32 _stateRoot
+    )
+        private
+        view
+        returns (bool)
+    {
+        for (uint256 i = 0; i < reportedStateRoots[_height].length; i++) {
+            if (reportedStateRoots[_height][i] == _stateRoot) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/contracts/core/AuxiliaryCore.sol
+++ b/contracts/core/AuxiliaryCore.sol
@@ -44,7 +44,7 @@ contract AuxiliaryCore is AuxiliaryCoreInterface, AuxiliaryCoreConfig {
      */
     struct OriginBlock {
         uint256 height;
-        bytes32 rootHash;
+        bytes32 stateRoot;
     }
 
     /* Public Variables */
@@ -74,19 +74,19 @@ contract AuxiliaryCore is AuxiliaryCoreInterface, AuxiliaryCoreConfig {
      *
      * @param _height The height in the Ethereum blockchain that the block is
      *                reported for.
-     * @param _stateRootHash The state root to report at the given height.
-     *                       Reverts if the same state root has been reported
-     *                       before.
+     * @param _stateRoot The state root to report at the given height.
+     *                   Reverts if the same state root has been reported
+     *                   before.
      */
     function reportOriginBlock(
         uint256 _height,
-        bytes32 _stateRootHash
+        bytes32 _stateRoot
     )
         external
         payable
     {
         require(
-            _stateRootHash != bytes32(0),
+            _stateRoot != bytes32(0),
             "The state root should not be `0`."
         );
 
@@ -97,7 +97,7 @@ contract AuxiliaryCore is AuxiliaryCoreInterface, AuxiliaryCoreConfig {
 
         OriginBlock memory reportedBlock = OriginBlock(
             _height,
-            _stateRootHash
+            _stateRoot
         );
 
         require(
@@ -105,8 +105,8 @@ contract AuxiliaryCore is AuxiliaryCoreInterface, AuxiliaryCoreConfig {
             "The given state root has already been reported at the same height."
         );
         
-        reportedOriginBlocks[_stateRootHash] = reportedBlock;
-        emit OriginBlockReported(_height, _stateRootHash);
+        reportedOriginBlocks[_stateRoot] = reportedBlock;
+        emit OriginBlockReported(_height, _stateRoot);
     }
 
     /* Private Functions */
@@ -125,8 +125,8 @@ contract AuxiliaryCore is AuxiliaryCoreInterface, AuxiliaryCoreConfig {
         view
         returns (bool)
     {
-        OriginBlock storage storedBlock = reportedOriginBlocks[_block.rootHash];
+        OriginBlock storage storedBlock = reportedOriginBlocks[_block.stateRoot];
 
-        return storedBlock.rootHash == _block.rootHash;
+        return storedBlock.stateRoot == _block.stateRoot;
     }
 }

--- a/contracts/core/AuxiliaryCoreConfig.sol
+++ b/contracts/core/AuxiliaryCoreConfig.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.4.23;
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @title Configuration constants for the AuxiliaryCore contract. */
+contract AuxiliaryCoreConfig {
+
+    /** The number of decimals of the base token. */
+    uint256 public constant DECIMALS_FACTOR = 10 ** uint256(18);
+
+    /**
+     * The cost in base tokens that it costs a validator to report a state
+     * root.
+     */
+    uint256 public constant COST_REPORT_STATE_ROOT = 1 * DECIMALS_FACTOR;
+}

--- a/contracts/core/AuxiliaryCoreInterface.sol
+++ b/contracts/core/AuxiliaryCoreInterface.sol
@@ -18,35 +18,20 @@ pragma solidity ^0.4.23;
 interface AuxiliaryCoreInterface {
 
     /**
-     * @notice Report an Ethereum state root at a specific height. You need to
-     *         send the appropriate value with the transaction in order for the
-     *         state root to be reported.
+     * @notice Report an Ethereum block's state root at a specific height. You
+     *         need to send the appropriate value with the transaction in order
+     *         for the state root to be reported.
      *
      * @param _height The height in the Ethereum blockchain that the state root
      *                is reported for.
-     * @param _stateRoot The state root to report at the given height. Reverts
-     *                   if the same state root has been reported for this
-     *                   height before.
+     * @param _stateRootHash The state root to report at the given height.
+     *                       Reverts if the same state root has been reported
+     *                       for this height before.
      */
-    function reportStateRoot(
+    function reportOriginBlock(
         uint256 _height,
-        bytes32 _stateRoot
+        bytes32 _stateRootHash
     )
         external
         payable;
-
-    /**
-     * @notice Returns all the state roots that have been reported at a given
-     *         height.
-     *
-     * @param _height The height for which to get the reported state roots.
-     *
-     * @return The state roots that have been reported at the given height.
-     */
-    function getReportedStateRoots(
-        uint256 _height
-    )
-        external
-        view
-        returns (bytes32[]);
 }

--- a/contracts/core/AuxiliaryCoreInterface.sol
+++ b/contracts/core/AuxiliaryCoreInterface.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.4.23;
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** @title The interface for the auxiliary core. */
+interface AuxiliaryCoreInterface {
+
+    /**
+     * @notice Report an Ethereum state root at a specific height. You need to
+     *         send the appropriate value with the transaction in order for the
+     *         state root to be reported.
+     *
+     * @param _height The height in the Ethereum blockchain that the state root
+     *                is reported for.
+     * @param _stateRoot The state root to report at the given height. Reverts
+     *                   if the same state root has been reported for this
+     *                   height before.
+     */
+    function reportStateRoot(
+        uint256 _height,
+        bytes32 _stateRoot
+    )
+        external
+        payable;
+
+    /**
+     * @notice Returns all the state roots that have been reported at a given
+     *         height.
+     *
+     * @param _height The height for which to get the reported state roots.
+     *
+     * @return The state roots that have been reported at the given height.
+     */
+    function getReportedStateRoots(
+        uint256 _height
+    )
+        external
+        view
+        returns (bytes32[]);
+}

--- a/contracts/core/OriginCore.sol
+++ b/contracts/core/OriginCore.sol
@@ -67,7 +67,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
 
     OstInterface public Ost;
 
-    uint256 public chainIdRemote;
+    uint256 public chainIdAuxiliary;
 
     /** Height of the open block. */
     uint256 public height;
@@ -84,19 +84,19 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
     /* Constructor */
 
     /**
-     * @param _chainIdRemote The id of the auxiliary chain that this core
-     *                       contract tracks.
+     * @param _chainIdAuxiliary The id of the auxiliary chain that this core
+     *                          contract tracks.
      * @param _ost The address of the OST ERC-20 token.
      */
     constructor(
-        uint256 _chainIdRemote,
+        uint256 _chainIdAuxiliary,
         address _ost
     )
         public
     {
         require(_ost != address(0), "Address for OST should not be zero.");
 
-        chainIdRemote = _chainIdRemote;
+        chainIdAuxiliary = _chainIdAuxiliary;
         Ost = OstInterface(_ost);
     }
 
@@ -169,12 +169,12 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
      *
      * @return The id of the remote chain.
      */
-    function chainIdRemote()
+    function chainIdAuxiliary()
         external
         view
         returns (uint256)
     {
-        return chainIdRemote;
+        return chainIdAuxiliary;
     }
 
     /**

--- a/contracts/core/OriginCoreInterface.sol
+++ b/contracts/core/OriginCoreInterface.sol
@@ -22,12 +22,12 @@ pragma solidity ^0.4.23;
 interface OriginCoreInterface {
 
     /**
-     * @notice Returns the chain id of the remote chain that this core is
+     * @notice Returns the chain id of the auxiliary chain that this core is
      *         tracking.
      *
      * @return The id of the remote chain.
      */
-    function chainIdRemote()
+    function chainIdAuxiliary()
         external
         view
         returns (uint256);

--- a/test/core/AuxiliaryCore.js
+++ b/test/core/AuxiliaryCore.js
@@ -1,0 +1,224 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+// Test: AuxiliaryCore.js
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const eventsDecoder = require('../lib/event_decoder.js');
+
+const AuxiliaryCore = artifacts.require('AuxiliaryCore');
+
+contract('OriginCore', async (accounts) => {
+    describe('reporting a block', async () => {
+        let auxiliaryCore;
+
+        beforeEach(async () => {
+            auxiliaryCore = await AuxiliaryCore.new(1);
+        });
+
+        it('should accept a correct state root report', async () => {
+            let expectedStateRoot = '0xb59b762b2a1d476556dd6163bc8ec39967c4debec82ee534c0aed7a143939ed2';
+            let chainHeight = 37;
+
+            await auxiliaryCore.reportStateRoot(
+                chainHeight,
+                expectedStateRoot,
+                {
+                    from: accounts[0],
+                    value: 10 ** 18
+                }
+            );
+
+            let reportedStateRoots = await auxiliaryCore.getReportedStateRoots.call(chainHeight);
+            // There was only a single block reported.
+            assert.strictEqual(
+                reportedStateRoots[0],
+                expectedStateRoot,
+                'The contract did not store the state root that was reported.'
+            );
+        });
+
+        it('should emit an event for a correct state root report', async () => {
+            let expectedStateRoot = '0xb59b762b2a1d476556dd6163bc8ec39967c4debec82ee534c0aed7a143939ed2';
+            let chainHeight = 37;
+
+            let tx = await auxiliaryCore.reportStateRoot(
+                chainHeight,
+                expectedStateRoot,
+                {
+                    from: accounts[0],
+                    value: 10 ** 18
+                }
+            );
+
+            let events = eventsDecoder.perform(tx.receipt, auxiliaryCore.address, auxiliaryCore.abi);
+            assert.strictEqual(
+                Number(events.StateRootReported.height),
+                chainHeight,
+                'The contract did not emit an event with the given chain height.'
+            );
+            assert.strictEqual(
+                events.StateRootReported.stateRoot,
+                expectedStateRoot,
+                'The contract did not emit an event with the given state root.'
+            );
+
+        });
+
+        it('should record all roots at a single height', async () => {
+            let expectedStateRootOne = '0xb59b762b2a1d476556dd6163bc8ec39967c4debec82ee534c0aed7a143939ed2';
+            let expectedStateRootTwo = '0xdedde29f6dd592919e6d855b65aa8f1b55172a83f2f4810a13758d9f58c13f54';
+            let chainHeight = 33;
+
+            // Report two different state roots
+            await auxiliaryCore.reportStateRoot(
+                chainHeight,
+                expectedStateRootOne,
+                {
+                    from: accounts[0],
+                    value: 10 ** 18
+                }
+            );
+            await auxiliaryCore.reportStateRoot(
+                chainHeight,
+                expectedStateRootTwo,
+                {
+                    from: accounts[0],
+                    value: 10 ** 18
+                }
+            );
+
+            let reportedStateRoots = await auxiliaryCore.getReportedStateRoots.call(chainHeight);
+            // There were two roots reported in order.
+            assert.strictEqual(
+                reportedStateRoots.length,
+                2,
+                'Reporting two state roots should lead to two stored roots.'
+            );
+            assert.strictEqual(
+                reportedStateRoots[0],
+                expectedStateRootOne,
+                'The first state root of the reported roots was not stored correctly.'
+            );
+            assert.equal(
+                reportedStateRoots[1],
+                expectedStateRootTwo,
+                'The second state root of the reported roots was not stored correctly.'
+            );
+
+        });
+
+        it('should reject a report with an invalid state root', async () => {
+            let invalidStateRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
+            let chainHeight = 12;
+
+            let hadError = false;
+            try {
+                await auxiliaryCore.reportStateRoot(
+                    chainHeight,
+                    invalidStateRoot,
+                    {
+                        from: accounts[0],
+                        value: 10 ** 18
+                    }
+                );
+            } catch (error) {
+                // TODO: Truffle v5 will support require messages with web3 1.0
+                assert(
+                    error.message.search('revert') > -1,
+                    'The contract should revert. Instead: ' + error.message
+                );
+                hadError = true;
+            }
+
+            assert(
+                hadError,
+                'The contract should throw an error when the state root is invalid.'
+            );
+        });
+
+        it('should reject a duplicate report', async () => {
+            let expectedStateRoot = '0xb59b762b2a1d476556dd6163bc8ec39967c4debec82ee534c0aed7a143939ed2';
+            let chainHeight = 3;
+
+            await auxiliaryCore.reportStateRoot(
+                chainHeight,
+                expectedStateRoot,
+                {
+                    from: accounts[0],
+                    value: 10 ** 18
+                }
+            );
+
+            // Reporting the same state root again should lead to an error.
+            let hadError = false;
+            try {
+                await auxiliaryCore.reportStateRoot(
+                    chainHeight,
+                    expectedStateRoot,
+                    {
+                        from: accounts[0],
+                        value: 10 ** 18
+                    }
+                );
+            } catch (error) {
+                // TODO: Truffle v5 will support require messages with web3 1.0
+                assert(
+                    error.message.search('revert') > -1,
+                    'The contract should revert. Instead: ' + error.message
+                );
+                hadError = true;
+            }
+
+            assert(
+                hadError,
+                'The contract should throw an error when the state root was reported before.'
+            );
+        });
+
+        it('should reject a report that is not paid for sufficiently', async () => {
+            let expectedStateRoot = '0xb59b762b2a1d476556dd6163bc8ec39967c4debec82ee534c0aed7a143939ed2';
+            let chainHeight = 3;
+
+            let hadError = false;
+            try {
+                await auxiliaryCore.reportStateRoot(
+                    chainHeight,
+                    expectedStateRoot,
+                    {
+                        from: accounts[0],
+                        value: 5 ** 18
+                    }
+                );
+            } catch (error) {
+                // TODO: Truffle v5 will support require messages with web3 1.0
+                assert(
+                    error.message.search('revert') > -1,
+                    'The contract should revert. Instead: ' + error.message
+                );
+                hadError = true;
+            }
+
+            assert(
+                hadError,
+                'The contract should throw an error when the report is not paid sufficiently.'
+            );
+        });
+
+    });
+});

--- a/test/core/AuxiliaryCore.js
+++ b/test/core/AuxiliaryCore.js
@@ -20,6 +20,7 @@
 // ----------------------------------------------------------------------------
 
 const eventsDecoder = require('../lib/event_decoder.js');
+const utils = require('../lib/utils.js');
 
 const AuxiliaryCore = artifacts.require('AuxiliaryCore');
 
@@ -127,28 +128,15 @@ contract('OriginCore', async (accounts) => {
             let invalidStateRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
             let chainHeight = 12;
 
-            let hadError = false;
-            try {
-                await auxiliaryCore.reportStateRoot(
+            await utils.expectRevert(
+                auxiliaryCore.reportStateRoot(
                     chainHeight,
                     invalidStateRoot,
                     {
                         from: accounts[0],
                         value: 10 ** 18
                     }
-                );
-            } catch (error) {
-                // TODO: Truffle v5 will support require messages with web3 1.0
-                assert(
-                    error.message.search('revert') > -1,
-                    'The contract should revert. Instead: ' + error.message
-                );
-                hadError = true;
-            }
-
-            assert(
-                hadError,
-                'The contract should throw an error when the state root is invalid.'
+                )
             );
         });
 
@@ -166,28 +154,15 @@ contract('OriginCore', async (accounts) => {
             );
 
             // Reporting the same state root again should lead to an error.
-            let hadError = false;
-            try {
-                await auxiliaryCore.reportStateRoot(
+            await utils.expectRevert(
+                auxiliaryCore.reportStateRoot(
                     chainHeight,
                     expectedStateRoot,
                     {
                         from: accounts[0],
                         value: 10 ** 18
                     }
-                );
-            } catch (error) {
-                // TODO: Truffle v5 will support require messages with web3 1.0
-                assert(
-                    error.message.search('revert') > -1,
-                    'The contract should revert. Instead: ' + error.message
-                );
-                hadError = true;
-            }
-
-            assert(
-                hadError,
-                'The contract should throw an error when the state root was reported before.'
+                )
             );
         });
 
@@ -195,30 +170,16 @@ contract('OriginCore', async (accounts) => {
             let expectedStateRoot = '0xb59b762b2a1d476556dd6163bc8ec39967c4debec82ee534c0aed7a143939ed2';
             let chainHeight = 3;
 
-            let hadError = false;
-            try {
-                await auxiliaryCore.reportStateRoot(
+            await utils.expectRevert(
+                auxiliaryCore.reportStateRoot(
                     chainHeight,
                     expectedStateRoot,
                     {
                         from: accounts[0],
                         value: 5 ** 18
                     }
-                );
-            } catch (error) {
-                // TODO: Truffle v5 will support require messages with web3 1.0
-                assert(
-                    error.message.search('revert') > -1,
-                    'The contract should revert. Instead: ' + error.message
-                );
-                hadError = true;
-            }
-
-            assert(
-                hadError,
-                'The contract should throw an error when the report is not paid sufficiently.'
+                )
             );
         });
-
     });
 });


### PR DESCRIPTION
An AuxiliaryCore contract tracks state roots of Ethereum at their
respective heights.
The cost to report a state root must be paid in the base token of the
auxiliary chain. This should prevent noise in the reports.

A state root can only be reported once per height.

Fixes #258