### PR TITLE
Extend blocks to wait

### DIFF
--- a/contracts/OpenSTUtility.sol
+++ b/contracts/OpenSTUtility.sol
@@ -94,10 +94,10 @@ contract OpenSTUtility is Hasher, OpsManaged, STPrimeConfig {
     /*
      *  Constants
      */
-    // ~2 weeks, assuming ~15s per block
-    uint256 public constant BLOCKS_TO_WAIT_LONG = 80667;
-    // ~1hour, assuming ~15s per block
-    uint256 public constant BLOCKS_TO_WAIT_SHORT = 240;
+    // ~3 weeks, assuming ~2s per block
+    uint256 public constant BLOCKS_TO_WAIT_LONG = 907200;
+    // ~3 days, assuming ~2s per block
+    uint256 public constant BLOCKS_TO_WAIT_SHORT = 129600;
 
     /*
      *  Storage

--- a/contracts/OpenSTValue.sol
+++ b/contracts/OpenSTValue.sol
@@ -69,10 +69,10 @@ contract OpenSTValue is OpsManaged, Hasher {
      */
     uint8 public constant TOKEN_DECIMALS = 18;
     uint256 public constant DECIMALSFACTOR = 10**uint256(TOKEN_DECIMALS);
-    // ~2 weeks, assuming ~15s per block
-    uint256 private constant BLOCKS_TO_WAIT_LONG = 80667;
-    // ~1hour, assuming ~15s per block
-    uint256 private constant BLOCKS_TO_WAIT_SHORT = 240;
+    // ~3 weeks, assuming ~15s per block
+    uint256 private constant BLOCKS_TO_WAIT_LONG = 120960;
+    // ~3 days, assuming ~15s per block
+    uint256 private constant BLOCKS_TO_WAIT_SHORT = 17280;
 
     /*
      *  Structures


### PR DESCRIPTION
Extend long and short waits to the relevant chain equivalents of 3 weeks and 3 days.

Tests do not need to be updated because they use mocks to set the periods to sensible durations for testing.