### PR TITLE
New validators are now added at new OSTblocks

### DIFF
--- a/test/core/AuxiliaryStake.js
+++ b/test/core/AuxiliaryStake.js
@@ -32,6 +32,13 @@ const ValidatorIndexEndHeight = 4;
 
 contract('AuxiliaryStake', async (accounts) => {
     describe('deploying an auxiliary stake contract', async () => {
+        /*
+         * Make the first address the default OSTblock gate to be able to
+         * call methods that change the set of validators from the default
+         * message caller address.
+         */
+        let defaultOstBlockGate = accounts[0];
+
         it('should store a correct list of initial validators', async () => {
             let expectedStakes = {
                 addresses: [
@@ -79,8 +86,16 @@ contract('AuxiliaryStake', async (accounts) => {
             };
 
             let auxiliaryStake = await AuxiliaryStake.new(
+                defaultOstBlockGate,
                 expectedStakes.addresses,
                 expectedStakes.values
+            );
+
+            let ostBlockGate = await auxiliaryStake.ostBlockGate.call();
+            assert.strictEqual(
+                ostBlockGate,
+                defaultOstBlockGate,
+                'The contract must store the correct OSTblock gate.'
             );
 
             // Check for all individual stakes to be recorded
@@ -118,9 +133,26 @@ contract('AuxiliaryStake', async (accounts) => {
             );
         });
 
+        it('should not accept a zero OSTblock gate', async () => {
+            await utils.expectRevert(
+                AuxiliaryStake.new(
+                    '0x0000000000000000000000000000000000000000',
+                    [
+                        '0x0000000000000000000000000000000000000001',
+                        '0x0000000000000000000000000000000000000002',
+                    ],
+                    [
+                        new BigNumber('1'),
+                        new BigNumber('2'),
+                    ]
+                )
+            );
+        });
+
         it('should not accept an empty validator set', async () => {
             await utils.expectRevert(
                 AuxiliaryStake.new(
+                    defaultOstBlockGate,
                     [],
                     []
                 )
@@ -130,6 +162,7 @@ contract('AuxiliaryStake', async (accounts) => {
         it('should not accept two arrays of different length', async () => {
             await utils.expectRevert(
                 AuxiliaryStake.new(
+                    defaultOstBlockGate,
                     [
                         '0x0000000000000000000000000000000000000001',
                         '0x0000000000000000000000000000000000000002',
@@ -144,6 +177,7 @@ contract('AuxiliaryStake', async (accounts) => {
         it('should not accept a zero stake', async () => {
             await utils.expectRevert(
                 AuxiliaryStake.new(
+                    defaultOstBlockGate,
                     [
                         '0x0000000000000000000000000000000000000001',
                         '0x0000000000000000000000000000000000000002',
@@ -159,6 +193,7 @@ contract('AuxiliaryStake', async (accounts) => {
         it('should not accept a zero address', async () => {
             await utils.expectRevert(
                 AuxiliaryStake.new(
+                    defaultOstBlockGate,
                     [
                         '0x0000000000000000000000000000000000000001',
                         '0x0000000000000000000000000000000000000000',
@@ -174,6 +209,7 @@ contract('AuxiliaryStake', async (accounts) => {
         it('should not accept the same address more than once', async () => {
             await utils.expectRevert(
                 AuxiliaryStake.new(
+                    defaultOstBlockGate,
                     [
                         '0x0000000000000000000000000000000000000001',
                         '0x0000000000000000000000000000000000000002',

--- a/test/core/TestAuxiliaryStake.sol
+++ b/test/core/TestAuxiliaryStake.sol
@@ -1,0 +1,363 @@
+pragma solidity ^0.4.23;
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "truffle/Assert.sol";
+import "truffle/DeployedAddresses.sol";
+import "../lib/RevertProxy.sol";
+import "../../contracts/core/AuxiliaryStake.sol";
+
+/**
+ * @title Wrapper to wrap auxiliary stake methods.
+ *
+ * @notice The wrapper is required to drop the return value from the method
+ *         under test. See also:
+ *         https://github.com/trufflesuite/truffle/issues/1001#issuecomment-39748268
+ *
+ * @dev Note that the wrapped methods do not have a return value. It is
+ *      required to drop it in order for the low-level call of the RevertProxy
+ *      to work.
+ */
+contract AuxiliaryStakeWrapper {
+
+    /** The wrapped contract. */
+    AuxiliaryStake auxiliaryStake;
+
+    /**
+     * @notice Setting the wrapped contruct. It is not necessarily known at
+     *         construction.
+     *
+     * @param _auxiliaryStake The address of the wrapped contract.
+     */
+    function setAuxiliaryStake(address _auxiliaryStake) public {
+        auxiliaryStake = AuxiliaryStake(_auxiliaryStake);
+    }
+
+    /**
+     * @notice Wrapper function for the wrapped `updateOstBlockHeight`.
+     *
+     * @param _auxiliaryAddresses The addresses of the validators.
+     * @param _stakes The stakes of the validators.
+     */
+    function updateOstBlockHeight(
+        address[] _auxiliaryAddresses,
+        uint256[] _stakes
+    )
+        public
+    {
+        auxiliaryStake.updateOstBlockHeight(
+            _auxiliaryAddresses,
+            _stakes
+        );
+    }
+}
+
+/**
+ * @title Test contract to test the external methods of AuxiliaryStake.
+ */
+contract TestAuxiliaryStake {
+
+    /* Private Variables */
+
+    /*
+     * Addresses and stakes are kept in storage as AuxiliaryStake expects
+     * dynamic arrays as arguments and arrays in memory are always fixed size
+     * in solidity.
+     */
+
+    address private initialAddress = address(1337);
+    address[] private initialAddresses;
+    address[] private updateAddresses;
+
+    uint256 private initialStake = uint256(1337);
+    uint256[] private initialStakes;
+    uint256[] private updateStakes;
+
+    RevertProxy private proxy;
+    AuxiliaryStake private stake;
+    AuxiliaryStakeWrapper private wrapper;
+
+    /* External Functions */
+
+    /** @notice Resetting the arrays for every test to run independent. */
+    function beforeEach() external {
+        initialAddresses.length = 0;
+        updateAddresses.length = 0;
+        initialStakes.length = 0;
+        updateStakes.length = 0;
+    }
+
+    function testUpdateBlock() external {
+        constructContracts();
+
+        Assert.equal(
+            stake.currentOstBlockHeight(),
+            uint256(0),
+            "OSTblock height after initialisation should be 0."
+        );
+        Assert.equal(
+            stake.totalStakes(uint256(0)),
+            initialStake,
+            "Total stake after initialisation should be 1337."
+        );
+
+        updateAddresses.push(address(2));
+        updateStakes.push(uint256(19));
+
+        /*
+         * Using the same proxy logic as in the test that is expected to fail
+         * below. The reason is to make sure that the provided gas to the
+         * proxy's execute method would be sufficient to not trigger an out-of-
+         * gas error and have a false-positive test below when expecting a
+         * revert.
+         */
+
+         /* Priming the proxy. */
+        AuxiliaryStakeWrapper(address(proxy)).updateOstBlockHeight(
+            updateAddresses,
+            updateStakes
+        );
+
+        /* Making the primed call from the proxy. */
+        bool result = proxy.execute.gas(200000)();
+        Assert.isTrue(
+            result,
+            "The stake contract must accept a valid new OSTblock."
+        );
+
+        Assert.equal(
+            stake.currentOstBlockHeight(),
+            uint256(1),
+            "OSTblock height after update should be 1."
+        );
+        Assert.equal(
+            stake.totalStakes(uint256(1)),
+            uint256(1356),
+            "Total stake after update should be 1356."
+        );
+        Assert.equal(
+            stake.totalStakes(uint256(0)),
+            initialStake,
+            "Initial total stake after update should still be initial."
+        );
+
+        /* Validator from construction. */
+        validateValidator(
+            initialAddress,
+            initialStake,
+            false,
+            uint256(0),
+            uint256(0)
+        );
+        /* The start height after the first update should be 1. */
+        validateValidator(
+            address(2),
+            uint256(19),
+            false,
+            uint256(1),
+            uint256(0)
+        );
+    }
+
+    function testUpdateBlockInvalidMessageSender() external {
+        initialAddresses.push(initialAddress);
+        initialStakes.push(initialStake);
+
+        wrapper = new AuxiliaryStakeWrapper();
+        /*
+         * Address 1 is not the wrapper, thus the wrapper is not allowed to
+         * call the method and it should revert.
+         */
+        stake = new AuxiliaryStake(
+            address(1),
+            initialAddresses,
+            initialStakes
+        );
+        wrapper.setAuxiliaryStake(address(stake));
+        proxy = new RevertProxy(address(wrapper));
+
+        updateAddresses.push(address(999));
+        updateStakes.push(uint256(344));
+        
+        expectRevertOnUpdateOstBlockHeight(
+            "The stake contract must revert if the caller is not the OSTblock gate."
+        );
+    }
+
+    function testUpdateBlockInputArraysMustBeOfSameLength() external {
+        constructContracts();
+
+        updateAddresses.push(address(85));
+        updateAddresses.push(address(86));
+        updateStakes.push(uint256(344));
+
+        expectRevertOnUpdateOstBlockHeight(
+            "The stake contract must revert if the addresses array is longer."
+        );
+
+        /* The other array may also not be longer. */
+        updateStakes.push(uint256(345));
+        updateStakes.push(uint256(346));
+
+        expectRevertOnUpdateOstBlockHeight(
+            "The stake contract must revert if the stakes array is longer."
+        );
+    }
+
+    function testUpdateBlockStakeMustBeGreaterZero() external {
+        constructContracts();
+
+        updateAddresses.push(address(85));
+        updateStakes.push(uint256(0));
+
+        expectRevertOnUpdateOstBlockHeight(
+            "The stake contract must revert if the stake is zero."
+        );
+    }
+
+    function testUpdateBlockValidatorAddressMustNotBeZero() external {
+        constructContracts();
+
+        updateAddresses.push(address(0));
+        updateStakes.push(uint256(30000));
+
+        expectRevertOnUpdateOstBlockHeight(
+            "The stake contract must revert if the address is zero."
+        );
+    }
+
+    function testUpdateBlockUpdateOstBlockWithRepeatedValidator() external {
+        constructContracts();
+
+        updateStakes.push(uint256(344));
+
+        expectRevertOnUpdateOstBlockHeight(
+            "The stake contract must revert if a validator address already exists."
+        );
+    }
+
+    /* Private Functions */
+
+    /**
+     * @notice Helper method to construct the contracts with default values and
+     *         dependencies.
+     */
+    function constructContracts() private {
+        initialAddresses.push(initialAddress);
+        initialStakes.push(initialStake);
+
+        wrapper = new AuxiliaryStakeWrapper();
+        stake = new AuxiliaryStake(
+            address(wrapper),
+            initialAddresses,
+            initialStakes
+        );
+        wrapper.setAuxiliaryStake(address(stake));
+        proxy = new RevertProxy(address(wrapper));
+    }
+
+    /**
+     * @notice Does a `updateOstBlockHeight()` call with the RevertProxy and
+     *         expects the method under test to revert.
+     *
+     * @param _errorMessage The message to print if the contract does not
+     *                      revert.
+     */
+    function expectRevertOnUpdateOstBlockHeight(string _errorMessage) private {
+        /* Priming the proxy. */
+        AuxiliaryStakeWrapper(address(proxy)).updateOstBlockHeight(
+            updateAddresses,
+            updateStakes
+        );
+
+        expectRevert(_errorMessage);
+    }
+
+    /**
+     * @notice Using the RevertProxy to make the currently primed call. Expects
+     *         the primed call to revert in the method under test.
+     *
+     * @param _errorMessage The message to print if the contract does not
+     *                      revert.
+     */
+    function expectRevert(string _errorMessage) private {
+        /* Making the primed call from the proxy. */
+        bool result = proxy.execute.gas(200000)();
+        Assert.isFalse(
+            result,
+            _errorMessage
+        );
+    }
+
+    /**
+     * @notice Gets a validator from the AuxiliaryStake address based on the
+     *         expected address and then compares all fields to their expected
+     *         values. Fails the test if any field does not match.
+     *
+     * @param _expectedAddress The expected address of the validator.
+     * @param _expectedStake The expected stake of the validator.
+     * @param _expectedEnded The expected ended of the validator.
+     * @param _expectedStartHeight The expected start height of the validator.
+     * @param _expectedEndHeight The expected end height of the validator.
+     */
+    function validateValidator(
+        address _expectedAddress,
+        uint256 _expectedStake,
+        bool _expectedEnded,
+        uint256 _expectedStartHeight,
+        uint256 _expectedEndHeight
+    )
+        private
+    {
+        address vAuxAddress;
+        uint256 vStake;
+        bool vEnded;
+        uint256 vStartHeight;
+        uint256 vEndHeight;
+        (
+            vAuxAddress,
+            vStake,
+            vEnded,
+            vStartHeight,
+            vEndHeight
+        ) = stake.validators(_expectedAddress);
+        
+        Assert.equal(
+            vAuxAddress,
+            _expectedAddress,
+            "Did not store the correct address of the validator."
+        );
+        Assert.equal(
+            vStake,
+            _expectedStake,
+            "Did not store the correct stake of the validator."
+        );
+        Assert.equal(
+            vEnded,
+            _expectedEnded,
+            "Did not store the correct ended of the validator."
+        );
+        Assert.equal(
+            vStartHeight,
+            _expectedStartHeight,
+            "Did not store the correct start height of the validator."
+        );
+        Assert.equal(
+            vEndHeight,
+            _expectedEndHeight,
+            "Did not store the correct end height of the validator."
+        );
+    }
+}

--- a/test/lib/RevertProxy.sol
+++ b/test/lib/RevertProxy.sol
@@ -1,0 +1,117 @@
+pragma solidity ^0.4.23;
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "truffle/Assert.sol";
+import "truffle/DeployedAddresses.sol";
+
+/**
+ * @title A proxy contract to catch and test for reverts in other contracts.
+ *
+ * @notice Use this contract as a proxy between the test contract and the
+ *         contract under test. It will catch reverts and return false if it
+ *         caught one.
+ *
+ * @dev An important caveat here is to recognize the contract caller,
+ *      msg.sender. If you add a proxy in between, then msg.sender will be the
+ *      proxy, which could break authorization and permissioning algorithms. If
+ *      your authorization system allows you to change the owner, you can get
+ *      around this constraint by setting the proxy to be the contract owner.
+ *      It’s also important to know that this only tests throw's at this
+ *      particular level.
+ *      It would be prudent to also ensure there isn’t anything faulty in the
+ *      proxy by creating a second test as a control. This test should be
+ *      called with the appropriate gas and use the proxy to test a function
+ *      where _no_ throw occurs, just to make sure the proxy is setup and
+ *      working as intended.
+ *      Because a throw essentially uses up all gas, one must make doubly sure
+ *      they catch the throw and not a legitimate out-of-gas (OOG) error. As
+ *      well, take care to manage sending Ether through the proxy (for tests
+ *      that require it) as that can be difficult as well.
+ *
+ *      See also test/core/TestAuxiliaryStake.sol
+ *
+ *      Usage:
+ *      contract TestThrower {
+ *          function testThrow() {
+ *              Thrower thrower = new Thrower();
+ *              // Set Thrower as the contract to forward requests to the target.
+ *              RevertProxy revertProxy = new RevertProxy(address(thrower));
+ *
+ *              // Prime the proxy.
+ *              Thrower(address(revertProxy)).doThrow();
+ *              // Execute the call that is supposed to revert.
+ *              // r will be false if it reverted. r will be true if it didn't.
+ *              // Make sure you send enough gas for your contract method.
+ *              bool r = revertProxy.execute.gas(200000)();
+ *
+ *              Assert.isFalse(r, “Should be false, as it should revert");
+ *          }
+ *      }
+ *
+ *      Inspired by:
+ *      https://truffleframework.com/tutorials/testing-for-throws-in-solidity-tests.
+ */
+contract RevertProxy {
+
+    /* Public Variables */
+
+    /** target is the address of the contract under test. */
+    address public target;
+
+    /** data stores the call data that will be sent to the method under test. */
+    bytes public data;
+
+    /* Constructor */
+
+    /**
+     * @param _target The address where the executed calls will be sent to.
+     */
+    constructor (address _target) public {
+        target = _target;
+    }
+
+    /* Public Functions */
+
+    /**
+     * @notice Updates the target of the proxy so that all subsequent execute
+     *         calls will be made to the new target.
+     *
+     * @param _newTarget The address of the contract where to send all execute
+     *                   calls to.
+     */
+    function updateTarget(address _newTarget) public {
+        target = _newTarget;
+    }
+
+    /**
+     * @notice The fallback function stores the call data so that a call to the
+     *         execute function will use the correct call data.
+     */
+    function() public {
+        data = msg.data;
+    }
+
+    /**
+     * @notice This will make the call to the target with the call data primed
+     *         in the fallback function.
+     *
+     * @return `true` if the call was successful and did not revert, `false` if
+     *         it reverted.
+     */
+    function execute() external returns (bool) {
+        return target.call(data);
+    }
+}


### PR DESCRIPTION
The OSTblock gate contract is allowed to update the OSTblock on the
auxiliary stake contract. It increases the OSTblock height and adds the
new validators.

The address of the OSTblock gate is set on construction and cannot be
changed later.

It is currently not allowed to remove validators. That will be added in
a later step and requires stitching with forward and rear validator sets
like described in the Casper FFG paper.

Refactored adding of new validators into a private method as it is used
when updating an OSTblock as well as on construction.

Added JavaScript tests to assert the correct behaviour when initialising
an auxiliary stake contract.

Added Solidity tests to test the actual update method. In order to test
for reverts, I added a revert proxy as described in the truffle
documentation.

Fixes #282