### PR TITLE
Unit Tests for Message Bus Library Contract

### DIFF
--- a/test/lib/TestMessageBus.sol
+++ b/test/lib/TestMessageBus.sol
@@ -41,7 +41,7 @@ contract TestMessageBus {
     Hasher hasher = new Hasher();
 
     /* Signature Verification Parameters */
-    address sender = address(0x8014986b452de9f00ff9b036dcbe522f918e2fe4);
+    address sender = address(0x8014986b452DE9f00ff9B036dcBe522f918E2fE4);
     bytes32 hashedMessage = 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a;
     bytes32 messageHash = MessageBus.messageDigest(
         hasher.stakeTypeHash(),
@@ -176,6 +176,122 @@ contract TestMessageBus {
 //            "Status not changed to DeclaredRevocation."
 //        );
 //    }
+
+    function testChangeInboxState()
+        external
+    {
+        bool isChanged;
+        MessageBus.MessageStatus nextState;
+
+        // Test Undeclared => Declared
+        messageBox.inbox[messageHash] = MessageBus.MessageStatus.Undeclared;
+        (isChanged, nextState) = MessageBus.changeInboxState(
+            messageBox,
+            messageHash
+        );
+        Assert.equal(
+            bool(isChanged),
+            true,
+            "isChanged not equal to true."
+        );
+        Assert.equal(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Declared),
+            "nextState not changed to Declared."
+        );
+
+        // Test Declared => Progressed
+        messageBox.inbox[messageHash] = MessageBus.MessageStatus.Declared;
+        (isChanged, nextState) = MessageBus.changeInboxState(
+            messageBox,
+            messageHash
+        );
+        Assert.equal(
+            bool(isChanged),
+            true,
+            "isChanged not equal to true."
+        );
+        Assert.equal(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Progressed),
+            "nextState not changed to Progressed."
+        );
+
+        // Test DeclaredRevocation => Revoked
+        messageBox.inbox[messageHash] = MessageBus.MessageStatus.DeclaredRevocation;
+        (isChanged, nextState) = MessageBus.changeInboxState(
+            messageBox,
+            messageHash
+        );
+        Assert.equal(
+            bool(isChanged),
+            true,
+            "isChanged not equal to true."
+        );
+        Assert.equal(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Revoked),
+            "nextState not changed to Revoked."
+        );
+    }
+
+    function testchangeOutboxState()
+        external
+    {
+        bool isChanged;
+        MessageBus.MessageStatus nextState;
+
+        // Test Undeclared => Declared
+        messageBox.outbox[messageHash] = MessageBus.MessageStatus.Undeclared;
+        (isChanged, nextState) = MessageBus.changeOutboxState(
+            messageBox,
+            messageHash
+        );
+        Assert.equal(
+            bool(isChanged),
+            true,
+            "isChanged not equal to true."
+        );
+        Assert.equal(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Declared),
+            "nextState not changed to Declared."
+        );
+
+        // Test Declared => Progressed
+        messageBox.outbox[messageHash] = MessageBus.MessageStatus.Declared;
+        (isChanged, nextState) = MessageBus.changeOutboxState(
+            messageBox,
+            messageHash
+        );
+        Assert.equal(
+            bool(isChanged),
+            true,
+            "isChanged not equal to true."
+        );
+        Assert.equal(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Progressed),
+            "nextState not changed to Progressed."
+        );
+
+        // Test DeclaredRevocation => Revoked
+        messageBox.outbox[messageHash] = MessageBus.MessageStatus.DeclaredRevocation;
+        (isChanged, nextState) = MessageBus.changeOutboxState(
+            messageBox,
+            messageHash
+        );
+        Assert.equal(
+            bool(isChanged),
+            true,
+            "isChanged not equal to true."
+        );
+        Assert.equal(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Revoked),
+            "nextState not changed to Revoked."
+        );
+    }
 
 
 }

--- a/test/lib/TestMessageBus.sol
+++ b/test/lib/TestMessageBus.sol
@@ -31,8 +31,10 @@ contract TestMessageBus is KeyValueStoreStub {
     }
 
     /* External Functions */
-    // TODO -ve test cases
-    // TODO move hardcoded values to data contract
+
+    /**
+     * @notice it tests progress inbox method of messageBus.
+     */
     function testProgressInbox()
         external
     {
@@ -59,6 +61,9 @@ contract TestMessageBus is KeyValueStoreStub {
         );
     }
 
+    /**
+     * @notice it tests verify signature method of messageBus.
+     */
     function testVerifySignature()
         external
     {
@@ -92,6 +97,9 @@ contract TestMessageBus is KeyValueStoreStub {
         );
     }
 
+    /**
+     * @notice it tests declare revocation method of messageBus.
+     */
     function testDeclareRevocationMessage()
         external
     {
@@ -119,6 +127,9 @@ contract TestMessageBus is KeyValueStoreStub {
         );
     }
 
+    /**
+     * @notice it tests change inbox state method of messageBus.
+     */
     function testChangeInboxState()
         external
     {
@@ -132,6 +143,26 @@ contract TestMessageBus is KeyValueStoreStub {
         (isChanged, nextState) = MessageBus.changeInboxState(
             messageBox,
             messageHash
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Undeclared),
+            "nextState should not be equal to Undeclared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Progressed),
+            "nextState should not be equal to Progressed."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.DeclaredRevocation),
+            "nextState should not be equal to DeclaredRevocation."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Revoked),
+            "nextState should not be equal to Revoked."
         );
         Assert.equal(
             bool(isChanged),
@@ -150,6 +181,26 @@ contract TestMessageBus is KeyValueStoreStub {
             messageBox,
             messageHash
         );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Undeclared),
+            "nextState should not be equal to Undeclared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Declared),
+            "nextState should not be equal to Declared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.DeclaredRevocation),
+            "nextState should not be equal to DeclaredRevocation."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Revoked),
+            "nextState should not be equal to Revoked."
+        );
         Assert.equal(
             bool(isChanged),
             true,
@@ -167,6 +218,26 @@ contract TestMessageBus is KeyValueStoreStub {
             messageBox,
             messageHash
         );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Undeclared),
+            "nextState should not be equal to Undeclared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Declared),
+            "nextState should not be equal to Declared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Progressed),
+            "nextState should not be equal to Progressed."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.DeclaredRevocation),
+            "nextState should not be equal to DeclaredRevocation."
+        );
         Assert.equal(
             bool(isChanged),
             true,
@@ -179,6 +250,9 @@ contract TestMessageBus is KeyValueStoreStub {
         );
     }
 
+    /**
+     * @notice it tests change outbox state method of messageBus.
+     */
     function testChangeOutboxState()
         external
     {
@@ -194,15 +268,35 @@ contract TestMessageBus is KeyValueStoreStub {
             messageBox,
             messageHash
         );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Undeclared),
+            "nextState should not be equal to Undeclared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Progressed),
+            "nextState should not be equal to Progressed."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.DeclaredRevocation),
+            "nextState should not be equal to DeclaredRevocation."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Revoked),
+            "nextState should not be equal to Revoked."
+        );
         Assert.equal(
             bool(isChanged),
             true,
-            "isChanged not equal to true."
+            "isChanged is not equal to true."
         );
         Assert.equal(
             uint256(nextState),
             uint256(MessageBus.MessageStatus.Declared),
-            "nextState not changed to Declared."
+            "nextState is not changed to Declared."
         );
 
         // Test Declared => Progressed
@@ -211,15 +305,35 @@ contract TestMessageBus is KeyValueStoreStub {
             messageBox,
             messageHash
         );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Undeclared),
+            "nextState should not be equal to Undeclared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Declared),
+            "nextState should not be equal to Declared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.DeclaredRevocation),
+            "nextState should not be equal to DeclaredRevocation."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Revoked),
+            "nextState should not be equal to Revoked."
+        );
         Assert.equal(
             bool(isChanged),
             true,
-            "isChanged not equal to true."
+            "isChanged is not equal to true."
         );
         Assert.equal(
             uint256(nextState),
             uint256(MessageBus.MessageStatus.Progressed),
-            "nextState not changed to Progressed."
+            "nextState is not changed to Progressed."
         );
 
         // Test DeclaredRevocation => Revoked
@@ -228,15 +342,35 @@ contract TestMessageBus is KeyValueStoreStub {
             messageBox,
             messageHash
         );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Undeclared),
+            "nextState should not be equal to Undeclared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Declared),
+            "nextState should not be equal to Declared."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.Progressed),
+            "nextState should not be equal to Progressed."
+        );
+        Assert.notEqual(
+            uint256(nextState),
+            uint256(MessageBus.MessageStatus.DeclaredRevocation),
+            "nextState should not be equal to DeclaredRevocation."
+        );
         Assert.equal(
             bool(isChanged),
             true,
-            "isChanged not equal to true."
+            "isChanged is not equal to true."
         );
         Assert.equal(
             uint256(nextState),
             uint256(MessageBus.MessageStatus.Revoked),
-            "nextState not changed to Revoked."
+            "nextState is not changed to Revoked."
         );
     }
 

--- a/test/lib/TestMessageBus.sol
+++ b/test/lib/TestMessageBus.sol
@@ -16,64 +16,36 @@ pragma solidity ^0.4.23;
 
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";
-import "../../contracts/gateway/MessageBus.sol";
-import "../../contracts/gateway/Hasher.sol";
+import "../../test/test_lib/KeyValueStoreStub.sol";
 
 /**
  * @title Tests the MessageBus library.
  */
-contract TestMessageBus {
+contract TestMessageBus is KeyValueStoreStub {
 
-    MessageBus.MessageBox messageBox;
+    constructor()
+        public
+        KeyValueStoreStub()
+    {
 
-    bytes32 unlockSecret = keccak256(abi.encodePacked('secret'));
-    bytes32 unlockSecret1 = keccak256(abi.encodePacked('secret1'));
-    bytes32 hashLock = keccak256(abi.encodePacked(unlockSecret));
-    bytes32 intentHash = keccak256(abi.encodePacked('intent'));
-    uint256 nonce = 1;
-    uint256 gasPrice = 0x12A05F200;
-    uint256 gasLimit = 0x12A05F200;
-    uint256 gasConsumed = 0;
-
-    bytes rlpEncodedParentNodes = '0xf8f8f8b18080a011eb05caf5fa62e9b0fffc9118cf6c7a6f10870db11d837223bf585fc7283b2c80a0be65b7596c589a734b53d15e0cc9f13eae2083bf0173b1c2baf1534d9273882d8080808080a0997f2ab256882c505e8887d9f7622a18a17dc5727a0e9d04d314e59d482a508780a088976b814f3477b2d25aa3992c31abc4a4299557a6e94ca7786a440b15a07f1e80a04b140101c7c54b2c4d69e4cf35a353d7d969e439c48fe7388eaec325f1bfe6578080f843a0390decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563a1a03132333400000000000000000000000000000000000000000000000000000008' ;
-    uint8 outboxOffset = 0;
-    bytes32 storageRoot = 0x70b4172eb30c495bf20b5b12224cd2380fccdd7ffa2292416b9dbdfc8511585d;
-    Hasher hasher = new Hasher();
-
-    /* Signature Verification Parameters */
-    address sender = address(0x8014986b452DE9f00ff9B036dcBe522f918E2fE4);
-    bytes32 hashedMessage = 0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a;
-    bytes32 messageHash = MessageBus.messageDigest(
-        hasher.stakeTypeHash(),
-        intentHash,
-        nonce,
-        gasPrice,
-        gasLimit
-    );
-    MessageBus.Message message = MessageBus.Message({
-        intentHash : intentHash,
-        nonce : nonce,
-        gasPrice : gasPrice,
-        gasLimit : gasLimit,
-        sender : sender,
-        hashLock : hashLock,
-        gasConsumed: gasConsumed
-    });
+    }
 
     /* External Functions */
-    // TODO test fail cases
-    // TODO refactor repeat code. in before callback
+    // TODO -ve test cases
     // TODO move hardcoded values to data contract
     function testProgressInbox()
         external
     {
+        bytes32 messageHash = getBytes32(
+            "MESSAGE_BUS_DIGEST"
+        );
         messageBox.inbox[messageHash] = MessageBus.MessageStatus.Declared;
 
         bytes32 returnedMessageHash = MessageBus.progressInbox(
             messageBox,
             hasher.stakeTypeHash(),
             message,
-            unlockSecret
+            getBytes32("UNLOCK_SECRET")
         );
         Assert.equal(
             bytes32(returnedMessageHash),
@@ -87,45 +59,34 @@ contract TestMessageBus {
         );
     }
 
-//    function testProgressInboxWithProof()
-//        external
-//    {
-//        bytes32 messageHash = getMessageDigest();
-//        setMessage();
-//        messageBox.inbox[messageHash] = MessageBus.MessageStatus.Declared;
-//        MessageBus.progressInboxWithProof(
-//            messageBox,
-//            hasher.stakeTypeHash(),
-//            message,
-//            rlpEncodedParentNodes,
-//            outboxOffset,
-//            storageRoot,
-//            MessageBus.MessageStatus.Declared
-//        );
-//
-//        Assert.equal(
-//            uint256(messageBox.inbox[messageHash]),
-//            uint256(MessageBus.MessageStatus.Progressed),
-//            "Status not changed to progressed."
-//        );
-//    }
-
     function testVerifySignature()
         external
     {
         bytes memory signature = hex"1d1491a8373bcd39c9b779edc17e391dcf5f34becae481594e7e9fc9f1df6807399d4d13735e0e54e95f848a648856c2499de7a94832192e2038e0374f14bc211b";
         Assert.equal(
-            MessageBus.verifySignature(hashedMessage, signature, address(0)),
+            MessageBus.verifySignature(
+                getBytes32("HASHED_MESSAGE_TO_SIGN"),
+                signature,
+                address(0)
+            ),
             false,
             "Signer is not verified when signer address is empty."
         );
         Assert.equal(
-            MessageBus.verifySignature(hashedMessage, '', sender),
+            MessageBus.verifySignature(
+                getBytes32("HASHED_MESSAGE_TO_SIGN"),
+                '',
+                getAddress("SENDER")
+            ),
             false,
             "Signer is not verified when signature is empty."
         );
         Assert.equal(
-            MessageBus.verifySignature(hashedMessage, signature, sender),
+            MessageBus.verifySignature(
+                getBytes32("HASHED_MESSAGE_TO_SIGN"),
+                signature,
+                getAddress("SENDER")
+            ),
             true,
             "Signer not verified."
         );
@@ -136,6 +97,9 @@ contract TestMessageBus {
     {
         // Calculated by hashing revocationMessage
         bytes memory revocationSignature = hex"bda7f05d7bcbac276482ff0809c532edd57b10cce5638d3dede72bfd73a3ef3140e200b0a0e313beacdb79491d387000949751f2e6fe7eec4c03044ecc14fc2d00";
+        bytes32 messageHash = getBytes32(
+            "MESSAGE_BUS_DIGEST"
+        );
         messageBox.outbox[messageHash] = MessageBus.MessageStatus.Declared;
         bytes32 returnedMessageHash = MessageBus.declareRevocationMessage(
             messageBox,
@@ -155,34 +119,14 @@ contract TestMessageBus {
         );
     }
 
-//    function testConfirmRevocation()
-//        external
-//    {
-//        bytes32 messageHash = getMessageDigest();
-//        setMessage();
-//        messageBox.inbox[messageHash] = MessageBus.MessageStatus.Declared;
-//        MessageBus.confirmRevocation(
-//            messageBox,
-//            hasher.stakeTypeHash(),
-//            message,
-//            rlpEncodedParentNodes,
-//            outboxOffset,
-//            storageRoot
-//        );
-//
-//        Assert.equal(
-//            uint256(messageBox.inbox[messageHash]),
-//            uint256(MessageBus.MessageStatus.DeclaredRevocation),
-//            "Status not changed to DeclaredRevocation."
-//        );
-//    }
-
     function testChangeInboxState()
         external
     {
         bool isChanged;
         MessageBus.MessageStatus nextState;
-
+        bytes32 messageHash = getBytes32(
+            "MESSAGE_BUS_DIGEST"
+        );
         // Test Undeclared => Declared
         messageBox.inbox[messageHash] = MessageBus.MessageStatus.Undeclared;
         (isChanged, nextState) = MessageBus.changeInboxState(
@@ -235,11 +179,14 @@ contract TestMessageBus {
         );
     }
 
-    function testchangeOutboxState()
+    function testChangeOutboxState()
         external
     {
         bool isChanged;
         MessageBus.MessageStatus nextState;
+        bytes32 messageHash = getBytes32(
+            "MESSAGE_BUS_DIGEST"
+        );
 
         // Test Undeclared => Declared
         messageBox.outbox[messageHash] = MessageBus.MessageStatus.Undeclared;
@@ -292,6 +239,5 @@ contract TestMessageBus {
             "nextState not changed to Revoked."
         );
     }
-
 
 }

--- a/test/test_lib/KeyValueStoreStub.sol
+++ b/test/test_lib/KeyValueStoreStub.sol
@@ -40,7 +40,7 @@ contract KeyValueStoreStub {
      *      mapping
      */
     function KeyValueStoreStub()
-        public
+        internal
     {
         // Stores uint256
         setUint("NONCE", 1);

--- a/test/test_lib/KeyValueStoreStub.sol
+++ b/test/test_lib/KeyValueStoreStub.sol
@@ -1,0 +1,154 @@
+pragma solidity ^0.4.23;
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "../../contracts/gateway/Hasher.sol";
+import "../../contracts/gateway/MessageBus.sol";
+
+/**
+ * @title Stub data used across tests.
+ */
+contract KeyValueStoreStub {
+
+    mapping(bytes32 => uint256) public uintStorage;
+    mapping(bytes32 => address) public addressStorage;
+    mapping(bytes32 => bytes32) public bytes32Storage;
+    mapping(bytes32 => bytes) public bytesStorage;
+
+    Hasher hasher = new Hasher();
+    MessageBus.MessageBox messageBox;
+    MessageBus.Message message;
+
+    function KeyValueStoreStub()
+        public
+    {
+        // Stores uint256
+        setUint("NONCE", 1);
+        setUint("GAS_PRICE", 0x12A05F200);
+        setUint("GAS_LIMIT", 0x12A05F200);
+        setUint("GAS_CONSUMED", 0);
+
+        // Store Address
+        setAddress(
+            "SENDER",
+            address(0x8014986b452DE9f00ff9B036dcBe522f918E2fE4)
+        );
+
+        // Store byte32
+        setBytes32(
+            "UNLOCK_SECRET",
+            keccak256(abi.encodePacked('secret'))
+        );
+        setBytes32(
+            "HASH_LOCK",
+            keccak256(abi.encodePacked(getBytes32("UNLOCK_SECRET")))
+        );
+        setBytes32(
+            "INTENT_HASH",
+            keccak256(abi.encodePacked('intent'))
+        );
+        setBytes32(
+            "HASHED_MESSAGE_TO_SIGN",
+            0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a
+        );
+
+        setBytes32(
+            "MESSAGE_BUS_DIGEST",
+            MessageBus.messageDigest(
+                hasher.stakeTypeHash(),
+                getBytes32("INTENT_HASH"),
+                getUint("NONCE"),
+                getUint("GAS_PRICE"),
+                getUint("GAS_LIMIT")
+        ));
+
+        // Set Message
+        message = MessageBus.Message({
+            intentHash : getBytes32("INTENT_HASH"),
+            nonce : getUint("NONCE"),
+            gasPrice : getUint("GAS_PRICE"),
+            gasLimit : getUint("GAS_LIMIT"),
+            sender : getAddress("SENDER"),
+            hashLock : getBytes32("HASH_LOCK"),
+            gasConsumed: getUint("GAS_CONSUMED")
+        });
+    }
+
+    /* Getter Public Functions */
+
+    function getUint(string key)
+        internal
+        returns (uint256)
+    {
+        return uintStorage[hashed(key)];
+    }
+
+    function getAddress(string key)
+        internal
+        returns (address)
+    {
+        return addressStorage[hashed(key)];
+    }
+
+    function getBytes32(string key)
+        internal
+        returns (bytes32)
+    {
+        return bytes32Storage[hashed(key)];
+    }
+
+    function getBytes(string key)
+        internal
+        returns (bytes)
+    {
+        return bytesStorage[hashed(key)];
+    }
+
+    /* Setter Public Functions */
+
+    function setUint(string key, uint256 value)
+        internal
+    {
+        uintStorage[hashed(key)] = value;
+    }
+
+    function setAddress(string key, address value)
+        internal
+    {
+        addressStorage[hashed(key)] = value;
+    }
+
+    function setBytes32(string key, bytes32 value)
+        internal
+    {
+        bytes32Storage[hashed(key)] = value;
+    }
+
+    function setBytes(string key, bytes value)
+        internal
+    {
+        bytesStorage[hashed(key)] = value;
+    }
+
+    /* Private Functions */
+
+    function hashed(string key)
+        internal
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(key));
+    }
+
+}

--- a/test/test_lib/KeyValueStoreStub.sol
+++ b/test/test_lib/KeyValueStoreStub.sol
@@ -31,6 +31,14 @@ contract KeyValueStoreStub {
     MessageBus.MessageBox messageBox;
     MessageBus.Message message;
 
+    /* Special Functions */
+
+    /**
+     * @notice contract constructor.
+     *
+     * @dev It sets the stub data based on their data type in respective
+     *      mapping
+     */
     function KeyValueStoreStub()
         public
     {
@@ -88,6 +96,13 @@ contract KeyValueStoreStub {
 
     /* Getter Public Functions */
 
+    /**
+     * @notice it returns uint256 data from uintStorage mapping.
+     *
+     * @param key mapping key for which uintStorage to look up.
+     *
+     * @return Stored uint for the key.
+     */
     function getUint(string key)
         internal
         returns (uint256)
@@ -95,6 +110,13 @@ contract KeyValueStoreStub {
         return uintStorage[hashed(key)];
     }
 
+    /**
+     * @notice it returns address from addressStorage mapping.
+     *
+     * @param key mapping key for which addressStorage to look up.
+     *
+     * @return Stored address for the key.
+     */
     function getAddress(string key)
         internal
         returns (address)
@@ -102,6 +124,13 @@ contract KeyValueStoreStub {
         return addressStorage[hashed(key)];
     }
 
+    /**
+     * @notice it returns bytes32 from bytes32Storage mapping.
+     *
+     * @param key mapping key for which bytes32Storage to look up.
+     *
+     * @return Stored bytes32 for the key.
+     */
     function getBytes32(string key)
         internal
         returns (bytes32)
@@ -109,6 +138,13 @@ contract KeyValueStoreStub {
         return bytes32Storage[hashed(key)];
     }
 
+    /**
+     * @notice it returns bytes from bytesStorage mapping.
+     *
+     * @param key mapping key for which bytesStorage to look up.
+     *
+     * @return Stored bytes for the key.
+     */
     function getBytes(string key)
         internal
         returns (bytes)
@@ -118,24 +154,52 @@ contract KeyValueStoreStub {
 
     /* Setter Public Functions */
 
+    /**
+     * @notice it sets address in uintStorage mapping.
+     *
+     * @param key value is set for this key.
+     * @param value to be set in uintStorage mapping.
+     *
+     */
     function setUint(string key, uint256 value)
         internal
     {
         uintStorage[hashed(key)] = value;
     }
 
+    /**
+     * @notice it sets address in addressStorage mapping.
+     *
+     * @param key value is set for this key.
+     * @param value to be set in addressStorage mapping.
+     *
+     */
     function setAddress(string key, address value)
         internal
     {
         addressStorage[hashed(key)] = value;
     }
 
+    /**
+     * @notice it sets bytes32 data in bytes32Storage mapping.
+     *
+     * @param key value is set for this key.
+     * @param value to be set in bytes32Storage mapping.
+     *
+     */
     function setBytes32(string key, bytes32 value)
         internal
     {
         bytes32Storage[hashed(key)] = value;
     }
 
+    /**
+     * @notice it sets bytes data in bytesStorage mapping.
+     *
+     * @param key value is set for this key.
+     * @param value to be set in bytesStorage mapping.
+     *
+     */
     function setBytes(string key, bytes value)
         internal
     {
@@ -144,11 +208,18 @@ contract KeyValueStoreStub {
 
     /* Private Functions */
 
-    function hashed(string key)
+    /**
+     * @notice it hashes the input after doing abi encodePacked.
+     *
+     * @param data to hash.
+     *
+     * @return hashed data.
+     */
+    function hashed(string data)
         internal
         returns (bytes32)
     {
-        return keccak256(abi.encodePacked(key));
+        return keccak256(abi.encodePacked(data));
     }
 
 }


### PR DESCRIPTION
- Covers unit tests of below functions
    ProgressInbox
    VerifySignature
    DeclareRevocationMessage
    ChangeInboxState
    ChangeOutboxState

- Created KeyValueStoreStub.sol which has all stub data stored.

- Requires are not tested because callData solidity has no support for encodePacking structs.
  https://github.com/ethereum/solidity/issues/4683