### PR TITLE
Fixed tests for Truffle v5

### DIFF
--- a/contracts/test/test_lib/RevertProxy.sol
+++ b/contracts/test/test_lib/RevertProxy.sol
@@ -14,9 +14,6 @@ pragma solidity ^0.4.23;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import "truffle/Assert.sol";
-import "truffle/DeployedAddresses.sol";
-
 /**
  * @title A proxy contract to catch and test for reverts in other contracts.
  *

--- a/test/core/TestPollingPlace.sol
+++ b/test/core/TestPollingPlace.sol
@@ -16,7 +16,7 @@ pragma solidity ^0.4.23;
 
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";
-import "../test_lib/RevertProxy.sol";
+import "../../contracts/test/test_lib/RevertProxy.sol";
 import "../../contracts/core/PollingPlace.sol";
 
 /**


### PR DESCRIPTION
All libraries/contracts used by tests must also be in the `contracts/` directory.