### PR TITLE
Core now uses SafeMath everywhere

### DIFF
--- a/contracts/core/BlockStore.sol
+++ b/contracts/core/BlockStore.sol
@@ -492,7 +492,7 @@ contract BlockStore is BlockStoreInterface {
 
         if (reportedBlocks[_blockHash].height > reportedBlocks[head].height) {
             head = _blockHash;
-            currentDynasty++;
+            currentDynasty = currentDynasty.add(1);
         }
 
         emit BlockFinalised(_blockHash);

--- a/contracts/core/OriginCore.sol
+++ b/contracts/core/OriginCore.sol
@@ -19,11 +19,13 @@ import "./OriginCoreConfig.sol";
 import "./OriginCoreInterface.sol";
 import "./Stake.sol";
 import "../lib/MetaBlock.sol";
+import "../lib/SafeMath.sol";
 
 /**
  * @title OriginCore is a meta-blockchain with staked validators on Ethereum.
  */
 contract OriginCore is OriginCoreInterface, OriginCoreConfig {
+    using SafeMath for uint256;
 
     /* Events */
 
@@ -183,7 +185,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
         MetaBlock.Header storage latestMetaBlockHeader = reportedHeaders[head];
 
         require(
-            latestMetaBlockHeader.kernel.height + 1 == _height,
+            latestMetaBlockHeader.kernel.height.add(1) == _height,
             "Height should be one more than last meta-block."
         );
 
@@ -301,7 +303,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
          * `height` is the current open meta-block. The latest committed block
          * is therefore at `height - 1`.
          */
-        return height - 1;
+        return height.sub(1);
     }
 
     /**

--- a/contracts/core/PollingPlace.sol
+++ b/contracts/core/PollingPlace.sol
@@ -292,14 +292,14 @@ contract PollingPlace is PollingPlaceInterface {
             "meta-block updates must be done by the registered meta-block gate."
         );
 
-        currentMetaBlockHeight++;
+        currentMetaBlockHeight = currentMetaBlockHeight.add(1);
 
         /*
          * Before adding the new validators, copy the total weights from the
          * previous height. The new validators' weights for this height will be
          * added on top in `addValidators()`.
          */
-        totalWeights[currentMetaBlockHeight] = totalWeights[currentMetaBlockHeight - 1];
+        totalWeights[currentMetaBlockHeight] = totalWeights[currentMetaBlockHeight.sub(1)];
         addValidators(_validators, _weights);
         updateCoreHeights(_originHeight, _auxiliaryHeight);
 
@@ -443,7 +443,9 @@ contract PollingPlace is PollingPlaceInterface {
                 0
             );
 
-            totalWeights[currentMetaBlockHeight] += weight;
+            totalWeights[currentMetaBlockHeight] = totalWeights[currentMetaBlockHeight].add(
+                weight
+            );
         }
     }
 
@@ -502,7 +504,9 @@ contract PollingPlace is PollingPlaceInterface {
         VoteMessage memory voteMessage = _voteObject.voteMessage;
 
         validatorTargetHeights[_validator.auxiliaryAddress] = voteMessage.targetHeight;
-        votesWeights[_voteHash] += validatorWeight(_validator, currentMetaBlockHeight);
+        votesWeights[_voteHash] = votesWeights[_voteHash].add(
+            validatorWeight(_validator, currentMetaBlockHeight)
+        );
 
         /*
          * Because the target must be within the currently open meta-block, the

--- a/contracts/core/PollingPlace.sol
+++ b/contracts/core/PollingPlace.sol
@@ -611,14 +611,14 @@ contract PollingPlace is PollingPlaceInterface {
         returns (uint256 required_)
     {
         // 2/3 are required (a supermajority).
-        required_ = (totalWeights[_metaBlockHeight].mul(2).div(3));
+        required_ = totalWeights[_metaBlockHeight].mul(2).div(3);
 
-        /**
+        /*
          * Solidity always rounds down, but we have to round up if there is a
          * remainder. It has to be *at least* 2/3.
          */
-        if (((totalWeights[_metaBlockHeight].mul(2)) % 3) > 0) {
-            required_++;
+        if (totalWeights[_metaBlockHeight].mul(2).mod(3) > 0) {
+            required_ = required_.add(1);
         }
     }
 

--- a/contracts/core/Stake.sol
+++ b/contracts/core/Stake.sol
@@ -16,11 +16,13 @@ pragma solidity ^0.4.23;
 
 import "../gateway/EIP20Interface.sol";
 import "./StakeInterface.sol";
+import "../lib/SafeMath.sol";
 
 /**
  * @title The Stake contract tracks deposits, logouts, slashings etc. on origin.
  */
 contract Stake is StakeInterface {
+    using SafeMath for uint256;
 
     /* Events */
 
@@ -288,7 +290,7 @@ contract Stake is StakeInterface {
     {
         verifyNewValidator(msg.sender, _validator, _amount);
 
-        uint256 startingHeight = height + 2;
+        uint256 startingHeight = height.add(2);
         registerNewValidator(msg.sender, _validator, _amount, startingHeight);
 
         emit NewDeposit(
@@ -384,7 +386,7 @@ contract Stake is StakeInterface {
     {
         assert(_closingHeight == height);
 
-        height++;
+        height = height.add(1);
 
         updatedValidators_ = updateAddresses[height];
         updatedWeights_ = updateWeights[height];
@@ -467,7 +469,9 @@ contract Stake is StakeInterface {
     {
         for (uint256 i = 0; i < validatorAddresses.length; i++) {
             address validator = validatorAddresses[i];
-            totalWeight_ += validatorWeightAtHeight(_height, validator);
+            totalWeight_ = totalWeight_.add(
+                validatorWeightAtHeight(_height, validator)
+            );
         }
     }
 


### PR DESCRIPTION
I replaced all mathematical operations with calls to SafeMath functions.
Exceptions were the loop variables in for loops where the biggest number
is limited by an array length.

Example:
`for (uint256 i = 0; i < anArray.length; i++)`
It is clear that `i` will never overflow.

Fixes #351