### PR TITLE
Core should have getter for gas target [383]

### DIFF
--- a/contracts/core/OriginCore.sol
+++ b/contracts/core/OriginCore.sol
@@ -60,6 +60,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
      * auxiliary chain before proposing a new meta-block.
      */
     uint256 public maxAccumulateGasLimit;
+
     /**
      * Mapping of block hashes to block headers that were reported with the
      * respective hash.

--- a/contracts/core/OriginCore.sol
+++ b/contracts/core/OriginCore.sol
@@ -210,7 +210,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
         );
 
         require(
-            _accumulatedGas > latestMetaBlockHeader.transition.gas,
+            _accumulatedGas > latestMetaBlockHeader.transition.accumulatedGas,
             "Gas consumed should be greater than last meta-block gas."
         );
 
@@ -343,13 +343,13 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
      *
      * @return Accumulated gas target.
      */
-    function getAccumulateGasTarget()
+    function getAccumulatedGasTarget()
         external
         view
         returns (uint256 accumulateGasTarget_)
     {
         MetaBlock.Header storage lastCommittedMetaBlock = reportedHeaders[head];
-        accumulateGasTarget_ = lastCommittedMetaBlock.transition.gas.add(
+        accumulateGasTarget_ = lastCommittedMetaBlock.transition.accumulatedGas.add(
             maxAccumulateGasLimit
         );
     }

--- a/contracts/core/OriginCore.sol
+++ b/contracts/core/OriginCore.sol
@@ -56,8 +56,8 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
     bytes32 public head;
 
     /**
-     * maximum amount of gas that a meta-block could accumulate for proposing
-     * a new meta-block.
+     * The maximum amount of gas that a meta-block could accumulate on an
+     * auxiliary chain before proposing a new meta-block.
      */
     uint256 public maxAccumulateGasLimit;
     /**
@@ -89,6 +89,10 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
      *                       of this meta-blockchain must have so that the
      *                       meta-blockchain is not considered halted. Used in
      *                       the constructor of the Stake contract.
+     * @param _maxAccumulateGasLimit The maximum amount of gas that a
+     *                               meta-block could accumulate on an
+     *                               auxiliary chain before proposing a new
+     *                               meta-block.
      */
     constructor(
         bytes32 _auxiliaryCoreIdentifier,
@@ -337,7 +341,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
     /**
      * @notice Get next accumulated gas target.
      *
-     * @return The state root of the meta-block.
+     * @return Accumulated gas target.
      */
     function getAccumulateGasTarget()
         external

--- a/contracts/core/OriginCore.sol
+++ b/contracts/core/OriginCore.sol
@@ -339,7 +339,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
     }
 
     /**
-     * @notice Get next accumulated gas target.
+     * @notice Get accumulated gas target for next meta-block.
      *
      * @return Accumulated gas target.
      */

--- a/contracts/core/OriginCoreInterface.sol
+++ b/contracts/core/OriginCoreInterface.sol
@@ -137,7 +137,7 @@ interface OriginCoreInterface {
      *
      * @return Accumulated gas target.
      */
-    function getAccumulateGasTarget()
+    function getAccumulatedGasTarget()
         external
         view
         returns (uint256 accumulateGasTarget_);

--- a/contracts/core/OriginCoreInterface.sol
+++ b/contracts/core/OriginCoreInterface.sol
@@ -133,7 +133,7 @@ interface OriginCoreInterface {
         returns (bytes32 stateRoot_);
 
     /**
-     * @notice Get next accumulated gas target.
+     * @notice Get accumulated gas target for next meta-block.
      *
      * @return Accumulated gas target.
      */

--- a/contracts/core/OriginCoreInterface.sol
+++ b/contracts/core/OriginCoreInterface.sol
@@ -131,4 +131,14 @@ interface OriginCoreInterface {
         external
         view
         returns (bytes32 stateRoot_);
+
+    /**
+     * @notice Get next accumulated gas target.
+     *
+     * @return Accumulated gas target.
+     */
+    function getAccumulateGasTarget()
+        external
+        view
+        returns (uint256 accumulateGasTarget_);
 }

--- a/contracts/lib/MetaBlock.sol
+++ b/contracts/lib/MetaBlock.sol
@@ -79,7 +79,7 @@ library MetaBlock {
          * The total gas that has been consumed on auxiliary for all blocks
          * that are inside this meta-block.
          */
-        uint256 gas;
+        uint256 accumulatedGas;
 
         /**
          * Dynasty of origin block within latest meta-block
@@ -132,7 +132,8 @@ library MetaBlock {
      *                          on the auxiliary chain.
      * @param _auxiliaryBlockHash The block hash where the meta-block closes
      *                          on the auxiliary chain.
-     * @param _gas The total consumed gas on auxiliary within this meta-block.
+     * @param _accumulatedGas The total consumed gas on auxiliary within this
+     *                        meta-block.
      * @param _originDynasty Dynasty of origin block within latest meta-block
      *                          reported at auxiliary chain.
      * @param _originBlockHash Block hash of origin block within latest
@@ -147,7 +148,7 @@ library MetaBlock {
         bytes32 _kernelHash,
         uint256 _auxiliaryDynasty,
         bytes32 _auxiliaryBlockHash,
-        uint256 _gas,
+        uint256 _accumulatedGas,
         uint256 _originDynasty,
         bytes32 _originBlockHash,
         bytes32 _transactionRoot
@@ -156,7 +157,7 @@ library MetaBlock {
         pure
         returns (bytes32)
     {
-        return keccak256(abi.encode(_gas));
+        return keccak256(abi.encode(_accumulatedGas));
     }
 
     /**

--- a/test/core/origin_core/constructor.js
+++ b/test/core/origin_core/constructor.js
@@ -29,20 +29,18 @@ const OriginCore = artifacts.require('OriginCore');
 contract('OriginCore.constructor()', async (accounts) => {
 
 
-    let originCore;
-    let auxiliaryCoreIdentifier = web3.utils.sha3("1"),
-        gas, transactionRoot, ost = accounts[0];
+    let originCore, gas, transactionRoot, ost, maxAccumulateGasLimit;
+    let auxiliaryCoreIdentifier = web3.utils.sha3("1");
     let minimumWeight = new BN('1');
 
     beforeEach(async () => {
-
-        ost = accounts[0]
-            , gas = 1000
-            , transactionRoot = web3.utils.sha3("1");
+        ost = accounts[0];
+        gas = new BN(1000);
+        transactionRoot = web3.utils.sha3("1");
+        maxAccumulateGasLimit = new BN(105000);
     });
 
     it('should be able to deploy Origin core', async function () {
-
 
         originCore = await OriginCore.new(
             auxiliaryCoreIdentifier,
@@ -50,6 +48,7 @@ contract('OriginCore.constructor()', async (accounts) => {
             gas,
             transactionRoot,
             minimumWeight,
+            maxAccumulateGasLimit
         );
 
         assert(web3.utils.isAddress(originCore.address));
@@ -63,6 +62,7 @@ contract('OriginCore.constructor()', async (accounts) => {
             gas,
             transactionRoot,
             minimumWeight,
+            maxAccumulateGasLimit
         );
 
         assert(web3.utils.isAddress(originCore.address));
@@ -80,6 +80,7 @@ contract('OriginCore.constructor()', async (accounts) => {
             gas,
             transactionRoot,
             minimumWeight,
+            maxAccumulateGasLimit
         );
 
         assert(web3.utils.isAddress(originCore.address));
@@ -99,6 +100,7 @@ contract('OriginCore.constructor()', async (accounts) => {
                 gas,
                 transactionRoot,
                 minimumWeight,
+                maxAccumulateGasLimit
             ),
         );
     });
@@ -114,7 +116,27 @@ contract('OriginCore.constructor()', async (accounts) => {
                 gas,
                 transactionRoot,
                 minimumWeight,
+                maxAccumulateGasLimit
             ),
         );
     });
+
+    it('should not deploy origin core if max accumulated gas limit is zero',
+        async function () {
+
+        maxAccumulateGasLimit = new BN(0);
+
+        await Utils.expectThrow(
+            OriginCore.new(
+                auxiliaryCoreIdentifier,
+                ost,
+                gas,
+                transactionRoot,
+                minimumWeight,
+                maxAccumulateGasLimit
+            ),
+            "Max accumulated gas limit should not be zero."
+    );
+  });
 });
+

--- a/test/core/origin_core/constructor.js
+++ b/test/core/origin_core/constructor.js
@@ -136,7 +136,7 @@ contract('OriginCore.constructor()', async (accounts) => {
                 maxAccumulateGasLimit
             ),
             "Max accumulated gas limit should not be zero."
-    );
-  });
+        );
+    });
 });
 

--- a/test/core/origin_core/getAccumulatedGasTarget.js
+++ b/test/core/origin_core/getAccumulatedGasTarget.js
@@ -22,10 +22,9 @@ const web3 = require('../../test_lib/web3.js');
 const BN = require('bn.js');
 const OriginCore = artifacts.require('OriginCore');
 
-contract('OriginCore.getAccumulateGasTarget()', async (accounts) => {
+contract('OriginCore.getAccumulatedGasTarget()', async (accounts) => {
 
   /**
-   * TODO:
    * @dev while writing this test commitMetaBlock function is not
    *      implemented, So once its updated the tests should be updated to use
    *      commitMetaBlock function. Currently this tests are using the genesis
@@ -49,14 +48,14 @@ contract('OriginCore.getAccumulateGasTarget()', async (accounts) => {
       gas,
       transactionRoot,
       minimumWeight,
-      maxAccumulateGasLimit
+      maxAccumulateGasLimit,
     );
   }
 
   /** Asserts the accumulated gas target */
   async function testAccumulatedGasTarget(){
     await deployOriginCore();
-    let accumulatedGasTarget = await originCore.getAccumulateGasTarget.call();
+    let accumulatedGasTarget = await originCore.getAccumulatedGasTarget.call();
     assert(
       accumulatedGasTarget.eq(gas.add(maxAccumulateGasLimit)),
       `Accumulated gas target should` +

--- a/test/core/origin_core/getAccumulatedGasTarget.js
+++ b/test/core/origin_core/getAccumulatedGasTarget.js
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 // ----------------------------------------------------------------------------
-// Test: get_accumulate_gas_target.js
 //
 // http://www.simpletoken.org/
 //

--- a/test/core/origin_core/get_accumulate_gas_target.js
+++ b/test/core/origin_core/get_accumulate_gas_target.js
@@ -1,0 +1,86 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+// Test: get_accumulate_gas_target.js
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+const web3 = require('../../test_lib/web3.js');
+const BN = require('bn.js');
+const OriginCore = artifacts.require('OriginCore');
+
+contract('OriginCore.getAccumulateGasTarget()', async (accounts) => {
+
+  /**
+   * TODO:
+   * @dev while writing this test commitMetaBlock function is not
+   *      implemented, So once its updated the tests should be updated to use
+   *      commitMetaBlock function. Currently this tests are using the genesis
+   *      meta block for testing
+   */
+
+  let originCore,
+    maxAccumulateGasLimit,
+    gas,
+    auxiliaryCoreIdentifier,
+    transactionRoot,
+    ost,
+    minimumWeight
+  ;
+
+  /** Deploys the origin core contract */
+  async function deployOriginCore(){
+    originCore = await OriginCore.new(
+      auxiliaryCoreIdentifier,
+      ost,
+      gas,
+      transactionRoot,
+      minimumWeight,
+      maxAccumulateGasLimit
+    );
+  }
+
+  /** Asserts the accumulated gas target */
+  async function testAccumulatedGasTarget(){
+    await deployOriginCore();
+    let accumulatedGasTarget = await originCore.getAccumulateGasTarget.call();
+    assert(
+      accumulatedGasTarget.eq(gas.add(maxAccumulateGasLimit)),
+      `Accumulated gas target should` +
+        `be ${gas.add(maxAccumulateGasLimit).toString(10)}`
+    )
+  }
+
+  beforeEach(async () => {
+    auxiliaryCoreIdentifier = web3.utils.sha3("1");
+    transactionRoot= web3.utils.sha3("1");
+    ost = accounts[0];
+    minimumWeight = new BN('1');
+  });
+
+  it('should return 200 as accumulate gas target', async function () {
+      gas = new BN('100');
+      maxAccumulateGasLimit = new BN('100');
+      await testAccumulatedGasTarget();
+  });
+
+  it('should return 1245 as accumulate gas target', async function () {
+    gas = new BN('245');
+    maxAccumulateGasLimit = new BN('1000');
+    await testAccumulatedGasTarget();
+  });
+
+});

--- a/test/core/origin_core/propose_block.js
+++ b/test/core/origin_core/propose_block.js
@@ -33,18 +33,19 @@ contract('OriginCore.proposeBlock()', async (accounts) => {
     let auxiliaryCoreIdentifier = web3.utils.sha3("1");
 
     let height, kernelHash, auxiliaryDynasty, auxiliaryBlockHash, gas,
-         originDynasty, originBlockHash, transactionRoot;
+         originDynasty, originBlockHash, transactionRoot, maxAccumulateGasLimit;
 
     beforeEach(async () => {
 
-        height = 1,
-             kernelHash = web3.utils.sha3("1"),
-             auxiliaryDynasty = 50,
-             auxiliaryBlockHash = web3.utils.sha3("1"),
-             gas = 1000,
-             originDynasty = 1,
-             originBlockHash = web3.utils.sha3("1"),
-             transactionRoot = web3.utils.sha3("1");
+        height = 1;
+        kernelHash = web3.utils.sha3("1");
+        auxiliaryDynasty = 50;
+        auxiliaryBlockHash = web3.utils.sha3("1");
+        gas = 1000;
+        originDynasty = 1;
+        originBlockHash = web3.utils.sha3("1");
+        transactionRoot = web3.utils.sha3("1");
+        maxAccumulateGasLimit = new BN(105000);
 
         let ost = accounts[0];
 
@@ -54,6 +55,7 @@ contract('OriginCore.proposeBlock()', async (accounts) => {
              0,
              web3.utils.sha3("1"),
              minimumWeight,
+             maxAccumulateGasLimit
         );
     });
 

--- a/test/gateway/eip20gateway/helpers/eip20gateway.js
+++ b/test/gateway/eip20gateway/helpers/eip20gateway.js
@@ -42,24 +42,6 @@ EIP20GatewayKlass.prototype = {
       hashLock = params.hashLock,
       signature = params.signature;
 
-    // Get the initial balances for all the addresses involved.
-    let initialStakerTokenBalance = await this.token.balanceOf.call(staker),
-      initialGatewayTokenBalance = await this.token.balanceOf.call(
-        this.gateway.address
-      ),
-      initialFacilitatorTokenBalance = await this.token.balanceOf.call(
-        txOptions.from
-      );
-
-    // Get the initial balances of base token for all the addresses involved.
-    let initialStakerBaseTokenBalance = await this.baseToken.balanceOf.call(staker),
-      initialGatewayBaseTokenBalance = await this.baseToken.balanceOf.call(
-        this.gateway.address
-      ),
-      initialFacilitatorBaseTokenBalance = await this.baseToken.balanceOf.call(
-        txOptions.from
-      );
-
     let initialBalance = await this._getBalances(
       staker,
       this.gateway.address,


### PR DESCRIPTION
This PR fixes #383

- added `maxAccumulateGasLimit` variable  in `OriginCore`.
- added `_maxAccumulateGasLimit` in `OriginCore` constructor params.
- added function `getAccumulateGasTarget` in `OriginCore`.
- added function `getAccumulateGasTarget` in `OriginCoreInterface`.

function `getAccumulateGasTarget` calculated the accumulated gas target by adding `maxAccumulateGasLimit` to the accumulated gas of current committed meta-block.

Please note: A commit meta-block function is not implemenented yet, the test cases should be updated later.