### PR TITLE
Auxiliary block store now uses correct transition object

### DIFF
--- a/contracts/core/AuxiliaryBlockStore.sol
+++ b/contracts/core/AuxiliaryBlockStore.sol
@@ -15,6 +15,7 @@ pragma solidity ^0.4.23;
 // limitations under the License.
 
 import "../lib/Block.sol";
+import "../lib/MetaBlock.sol";
 import "../lib/SafeMath.sol";
 import "./BlockStore.sol";
 
@@ -27,11 +28,32 @@ contract AuxiliaryBlockStore is BlockStore {
 
     /* Variables */
 
-    /** Maps a block hash to the accumulated gas at that block. */
+    /** A mapping of block hashes to their respective accumulated gas. */
     mapping(bytes32 => uint256) public accumulatedGases;
 
-    /** Maps a block hash to the accumulated transaction root at that block. */
+    /**
+     * A mapping of block hashes to their respective accumulated transaction
+     * root.
+     */
     mapping(bytes32 => bytes32) public accumulatedTransactionRoots;
+
+    /**
+     * A mapping of auxiliary block hashes to the current origin dynasty at the
+     * time of reporting the auxiliary block.
+     */
+    mapping(bytes32 => uint256) public originDynasties;
+
+    /**
+     * A mapping of auxiliary block hashes to the latest finalized origin block
+     * hash at the time of reporting the auxiliary block.
+     */
+    mapping(bytes32 => bytes32) public originBlockHashes;
+
+    /** The hash of the currently active kernel. */
+    bytes32 public kernelHash;
+
+    /** The corresponding origin block store that tracks the origin chain. */
+    BlockStore public originBlockStore;
 
     /* Constructor */
 
@@ -47,6 +69,9 @@ contract AuxiliaryBlockStore is BlockStore {
      *                     checkpoint to the next.
      * @param _pollingPlace The address of the polling place address. Only the
      *                      polling place may call the justify method.
+     * @param _originBlockStore The address where the origin block store is
+     *                          deployed. Required to get the latest
+     *                          observations of origin for the transition hash.
      * @param _initialBlockHash The block hash of the initial starting block.
      * @param _initialStateRoot The state root of the initial starting block.
      * @param _initialBlockHeight The block height of the initial starting
@@ -61,6 +86,7 @@ contract AuxiliaryBlockStore is BlockStore {
         bytes20 _coreIdentifier,
         uint256 _epochLength,
         address _pollingPlace,
+        address _originBlockStore,
         bytes32 _initialBlockHash,
         bytes32 _initialStateRoot,
         uint256 _initialBlockHeight,
@@ -77,6 +103,12 @@ contract AuxiliaryBlockStore is BlockStore {
         )
         public
     {
+        require(
+            _originBlockStore != address(0),
+            "The given origin block store address must not be zero."
+        );
+
+        originBlockStore = BlockStore(_originBlockStore);
         accumulatedGases[_initialBlockHash] = _initialGas;
         accumulatedTransactionRoots[_initialBlockHash] = _initialTransactionRoot;
     }
@@ -111,16 +143,19 @@ contract AuxiliaryBlockStore is BlockStore {
         success_ = super.reportBlock_(header);
 
         if (success_) {
-            accumulatedGases[header.blockHash] = accumulatedGases[header.parentHash].add(
+            accumulatedGases[header.blockHash] = accumulatedGases[parent.blockHash].add(
                 header.gasUsed
             );
 
             accumulatedTransactionRoots[header.blockHash] = keccak256(
                 abi.encode(
-                    accumulatedTransactionRoots[header.parentHash],
+                    accumulatedTransactionRoots[parent.blockHash],
                     header.transactionRoot
                 )
             );
+
+            originDynasties[header.blockHash] = originBlockStore.currentDynasty();
+            originBlockHashes[header.blockHash] = originBlockStore.head();
         }
     }
 
@@ -159,6 +194,37 @@ contract AuxiliaryBlockStore is BlockStore {
             valid_ = false;
             reason_ = "The source must be an ancestor of the target.";
         }
+    }
+
+    /**
+     * @notice Takes a transition hash and checks that the given checkpoint has
+     *         the same transition hash.
+     *
+     * @param _transitionHash The hash to check.
+     * @param _blockHash The checkpoint to test the hash against.
+     *
+     * @return `true` if the given checkpoint has the same transition hash.
+     */
+    function isValidTransitionHash(
+        bytes32 _transitionHash,
+        bytes32 _blockHash
+    )
+        internal
+        view
+        returns (bool valid_)
+    {
+        bytes32 expectedTransitionHash = MetaBlock.hashAuxiliaryTransition(
+            coreIdentifier,
+            kernelHash,
+            checkpoints[_blockHash].dynasty,
+            _blockHash,
+            accumulatedGases[_blockHash],
+            originDynasties[_blockHash],
+            originBlockHashes[_blockHash],
+            accumulatedTransactionRoots[_blockHash]
+        );
+
+        valid_ = _transitionHash == expectedTransitionHash;
     }
 
     /* Private Functions */

--- a/contracts/core/BlockStore.sol
+++ b/contracts/core/BlockStore.sol
@@ -211,6 +211,24 @@ contract BlockStore is BlockStoreInterface {
     /* External Functions */
 
     /**
+     * @notice Returns the current head that is finalized in the block store.
+     *
+     * @return head_ The block hash of the head.
+     */
+    function getHead() external view returns (bytes32 head_) {
+        head_ = head;
+    }
+
+    /**
+     * @notice Returns the current dynasty in the block store.
+     *
+     * @return dynasty_ The current dynasty.
+     */
+    function getCurrentDynasty() external view returns (uint256 dynasty_) {
+        dynasty_ = currentDynasty;
+    }
+
+    /**
      * @notice Report a block. A reported block header is stored and can then
      *         be part of subsequent votes.
      *
@@ -479,6 +497,32 @@ contract BlockStore is BlockStoreInterface {
         }
     }
 
+    /**
+     * @notice Takes a transition hash and checks that the given block results
+     *         in the same transition hash.
+     *
+     * @param _transitionHash The hash to check.
+     * @param _blockHash The block to test the hash against.
+     *
+     * @return `true` if the given block results in the same transition hash.
+     */
+    function isValidTransitionHash(
+        bytes32 _transitionHash,
+        bytes32 _blockHash
+    )
+        internal
+        view
+        returns (bool valid_)
+    {
+        bytes32 expectedHash = MetaBlock.hashOriginTransition(
+            checkpoints[_blockHash].dynasty,
+            _blockHash,
+            coreIdentifier
+        );
+
+        valid_ = _transitionHash == expectedHash;
+    }
+
     /* Private Functions */
 
     /**
@@ -648,32 +692,6 @@ contract BlockStore is BlockStoreInterface {
         uint256 higherHeight = reportedBlocks[_higherBlockHash].height;
         uint256 blockDistance = higherHeight.sub(lowerHeight);
         epochDistance_ = blockDistance.div(epochLength);
-    }
-
-    /**
-     * @notice Takes a transition hash and checks that the given block results
-     *         in the same transition hash.
-     *
-     * @param _transitionHash The hash to check.
-     * @param _blockHash The block to test the hash against.
-     *
-     * @return `true` if the given block results in the same transition hash.
-     */
-    function isValidTransitionHash(
-        bytes32 _transitionHash,
-        bytes32 _blockHash
-    )
-        private
-        view
-        returns (bool valid_)
-    {
-        bytes32 expectedHash = MetaBlock.hashOriginTransition(
-            checkpoints[_blockHash].dynasty,
-            _blockHash,
-            coreIdentifier
-        );
-
-        valid_ = _transitionHash == expectedHash;
     }
 
     /**

--- a/contracts/core/BlockStoreInterface.sol
+++ b/contracts/core/BlockStoreInterface.sol
@@ -18,6 +18,20 @@ pragma solidity ^0.4.23;
 interface BlockStoreInterface {
 
     /**
+     * @notice Returns the current head that is finalized in the block store.
+     *
+     * @return head_ The block hash of the head.
+     */
+    function getHead() external view returns (bytes32 head_);
+
+    /**
+     * @notice Returns the current dynasty in the block store.
+     *
+     * @return dynasty_ The current dynasty.
+     */
+    function getCurrentDynasty() external view returns (uint256 dynasty_);
+
+    /**
      * @notice Report a block. A reported block header is stored and can then
      *         be part of subsequent votes.
      *

--- a/contracts/core/OriginCore.sol
+++ b/contracts/core/OriginCore.sol
@@ -43,10 +43,12 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
 
     OstInterface public Ost;
 
-    bytes32 public auxiliaryCoreIdentifier;
+    /** The core identifier of the tracked auxiliary chain. */
+    bytes20 public auxiliaryCoreIdentifier;
 
     /** The stake contract that tracks deposits and weights. */
     StakeInterface public stake;
+
     /** Height of the open block. */
     uint256 public height;
 
@@ -84,7 +86,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
      *                       the constructor of the Stake contract.
      */
     constructor(
-        bytes32 _auxiliaryCoreIdentifier,
+        bytes20 _auxiliaryCoreIdentifier,
         address _ost,
         uint256 _initialAuxiliaryGas,
         bytes32 _initialTransactionRoot,
@@ -141,7 +143,7 @@ contract OriginCore is OriginCoreInterface, OriginCoreConfig {
      */
     function proposeBlock(
         uint256 _height,
-        bytes32 _coreIdentifier,
+        bytes20 _coreIdentifier,
         bytes32 _kernelHash,
         uint256 _auxiliaryDynasty,
         bytes32 _auxiliaryBlockHash,

--- a/contracts/core/OriginCoreInterface.sol
+++ b/contracts/core/OriginCoreInterface.sol
@@ -42,7 +42,7 @@ interface OriginCoreInterface {
      */
     function proposeBlock(
         uint256 _height,
-        bytes32 _coreIdentifier,
+        bytes20 _coreIdentifier,
         bytes32 _kernelHash,
         uint256 _auxiliaryDynasty,
         bytes32 _auxiliaryBlockHash,

--- a/contracts/test/MockGatewayBase.sol
+++ b/contracts/test/MockGatewayBase.sol
@@ -16,6 +16,7 @@ contract MockGatewayBase is GatewayBase {
         uint256 _bounty,
         address _organisation
     )
+        public
         GatewayBase(
             _core,
             _messageBus,
@@ -47,7 +48,7 @@ contract MockGatewayBase is GatewayBase {
      *
      *  @return `true` if Gateway account is proved
      */
-  function proveGateway(
+    function proveGateway(
         uint256 _blockHeight,
         bytes _rlpEncodedAccount,
         bytes _rlpParentNodes

--- a/contracts/test/core/BlockStoreMock.sol
+++ b/contracts/test/core/BlockStoreMock.sol
@@ -1,7 +1,5 @@
 pragma solidity ^0.4.23;
 
-/* solium-disable */
-
 // Copyright 2018 OpenST Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,9 +27,11 @@ contract BlockStoreMock is BlockStoreInterface {
     /** Emitted when the justify method is called. To be caught by tests. */
     event Justified(bytes32 _source, bytes32 _target);
 
-    /* Public Variable */
+    /* Public Variables */
 
     /* Return variables for the various methods. */
+    bytes32 public head;
+    uint256 public currentDynasty;
     bool public reportBlockSuccess;
     bytes32 public stateRoot;
     uint256 public latestBlockHeight;
@@ -41,6 +41,14 @@ contract BlockStoreMock is BlockStoreInterface {
     /* External Functions */
 
     /* Setter functions to set the wanted return values for testing. */
+
+    function setHead(bytes32 _head) external {
+        head = _head;
+    }
+
+    function setCurrentDynasty(uint256 _currentDynasty) external {
+        currentDynasty = _currentDynasty;
+    }
 
     function setReportBlockSuccess(bool _success) external {
         reportBlockSuccess = _success;
@@ -63,6 +71,14 @@ contract BlockStoreMock is BlockStoreInterface {
     }
 
     /* The methods of the interface, returning values from storage. */
+
+    function getHead() external view returns (bytes32) {
+        return head;
+    }
+
+    function getCurrentDynasty() external view returns (uint256) {
+        return currentDynasty;
+    }
 
     function reportBlock(
         bytes

--- a/test/core/auxiliary_block_store/constructor.js
+++ b/test/core/auxiliary_block_store/constructor.js
@@ -22,14 +22,22 @@ const BN = require('bn.js');
 const Utils = require('../../test_lib/utils.js');
 
 const AuxiliaryBlockStore = artifacts.require('AuxiliaryBlockStore');
+const BlockStoreMock = artifacts.require('BlockStoreMock');
 
 contract('AuxiliaryBlockStore.constructor()', async (accounts) => {
+
+    let originBlockStore;
+
+    beforeEach(async () => {
+        originBlockStore = await BlockStoreMock.new();
+    });
 
     it('should accept a valid construction', async () => {
         await AuxiliaryBlockStore.new(
             '0x0000000000000000000000000000000000000001',
             10,
             accounts[0],
+            originBlockStore.address,
             '0x7f1034f3d32a11c606f8ae8265344d2ab06d71500289df6f9cac2e013990830c',
             '0xb6a85955e3671040901a17db85b121550338ad1a0071ca13d196d19df31f56ca',
             0,
@@ -43,6 +51,7 @@ contract('AuxiliaryBlockStore.constructor()', async (accounts) => {
             '0x0000000000000000000000000000000000000001',
             10,
             accounts[0],
+            originBlockStore.address,
             '0x7f1034f3d32a11c606f8ae8265344d2ab06d71500289df6f9cac2e013990830c',
             '0xb6a85955e3671040901a17db85b121550338ad1a0071ca13d196d19df31f56ca',
             0,
@@ -64,6 +73,7 @@ contract('AuxiliaryBlockStore.constructor()', async (accounts) => {
                 '0x0000000000000000000000000000000000000001',
                 0,
                 accounts[0],
+                originBlockStore.address,
                 '0x7f1034f3d32a11c606f8ae8265344d2ab06d71500289df6f9cac2e013990830c',
                 '0xb6a85955e3671040901a17db85b121550338ad1a0071ca13d196d19df31f56ca',
                 0,
@@ -80,6 +90,7 @@ contract('AuxiliaryBlockStore.constructor()', async (accounts) => {
                 '0x0000000000000000000000000000000000000001',
                 10,
                 '0x0000000000000000000000000000000000000000',
+                originBlockStore.address,
                 '0x7f1034f3d32a11c606f8ae8265344d2ab06d71500289df6f9cac2e013990830c',
                 '0xb6a85955e3671040901a17db85b121550338ad1a0071ca13d196d19df31f56ca',
                 0,
@@ -90,12 +101,30 @@ contract('AuxiliaryBlockStore.constructor()', async (accounts) => {
         );
     });
 
+    it('should not accept a zero origin block store address', async () => {
+        await Utils.expectRevert(
+            AuxiliaryBlockStore.new(
+                '0x0000000000000000000000000000000000000001',
+                10,
+                accounts[0],
+                '0x0000000000000000000000000000000000000000',
+                '0x7f1034f3d32a11c606f8ae8265344d2ab06d71500289df6f9cac2e013990830c',
+                '0xb6a85955e3671040901a17db85b121550338ad1a0071ca13d196d19df31f56ca',
+                0,
+                new BN('21000'),
+                '0x5fe50b260da6308036625b850b5d6ced6d0a9f814c0688bc91ffb7b7a3a54b67',
+            ),
+            'The given origin block store address must not be zero.'
+        );
+    });
+
     it('should not accept a zero initial block hash', async () => {
         await Utils.expectRevert(
             AuxiliaryBlockStore.new(
                 '0x0000000000000000000000000000000000000001',
                 10,
                 accounts[0],
+                originBlockStore.address,
                 '0x0000000000000000000000000000000000000000000000000000000000000000',
                 '0xb6a85955e3671040901a17db85b121550338ad1a0071ca13d196d19df31f56ca',
                 0,
@@ -112,6 +141,7 @@ contract('AuxiliaryBlockStore.constructor()', async (accounts) => {
                 '0x0000000000000000000000000000000000000001',
                 10,
                 accounts[0],
+                originBlockStore.address,
                 '0x7f1034f3d32a11c606f8ae8265344d2ab06d71500289df6f9cac2e013990830c',
                 '0x0000000000000000000000000000000000000000000000000000000000000000',
                 0,
@@ -139,6 +169,7 @@ contract('AuxiliaryBlockStore.constructor()', async (accounts) => {
                     '0x0000000000000000000000000000000000000001',
                     testDate.epochLength,
                     accounts[0],
+                    originBlockStore.address,
                     '0x7f1034f3d32a11c606f8ae8265344d2ab06d71500289df6f9cac2e013990830c',
                     '0xb6a85955e3671040901a17db85b121550338ad1a0071ca13d196d19df31f56ca',
                     testDate.initialBlockHeight,

--- a/test/core/block_store/latestBlockHeight.js
+++ b/test/core/block_store/latestBlockHeight.js
@@ -68,7 +68,7 @@ contract('BlockStore.latestBlockHeight()', async (accounts) => {
     });
 
     it('should return the correct block height', async () => {
-        let testData = [
+        let testJustifications = [
             {
                 source: blockHashAtTen,
                 target: blockHashAtTwenty,
@@ -86,16 +86,16 @@ contract('BlockStore.latestBlockHeight()', async (accounts) => {
             },
         ];
 
-        let count = testData.length;
+        let count = testJustifications.length;
         for (i = 0; i < count; i++) {
-            let testDate = testData[i];
+            let testJustification = testJustifications[i];
 
-            await blockStore.justify(testDate.source, testDate.target);
+            await blockStore.justify(testJustification.source, testJustification.target);
             let height = await blockStore.latestBlockHeight.call();
             assert(
-                height.eq(testDate.expectedHeight),
+                height.eq(testJustification.expectedHeight),
                 "The  wrong height was returned. Expected: " + 
-                testDate.expectedHeight + " Actual: " + height
+                testJustification.expectedHeight + " Actual: " + height
             );
         }
     });

--- a/test/lib/TestMetaBlock.sol
+++ b/test/lib/TestMetaBlock.sol
@@ -1,0 +1,57 @@
+pragma solidity ^0.4.23;
+
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "truffle/Assert.sol";
+import "../../contracts/lib/MetaBlock.sol";
+
+/**
+ * @title Tests the MetaBlock library.
+ */
+contract TestMetaBlock {
+
+    function testHashAuxiliaryTransition() external {
+        bytes32 actualHash = MetaBlock.hashAuxiliaryTransition(
+            bytes20(hex"84739574832097584935602afcbdef6549875016"),
+            bytes32(hex"14739574832097584935602afcbdef65498750164935602afcbdef6549875011"),
+            uint256(1337),
+            bytes32(hex"24739574832097584935602afcbdef65498750164935602afcbdef6549875012"),
+            uint256(19851209),
+            uint256(20181025),
+            bytes32(hex"34739574832097584935602afcbdef65498750164935602afcbdef6549875013"),
+            bytes32(hex"44739574832097584935602afcbdef65498750164935602afcbdef6549875014")
+        );
+
+        Assert.equal(
+            actualHash,
+            hex"c74ca259ea4286e887d3a4a5174a47e0c59152e8ccac4f7c37de6ddee4c750d5",
+            ""
+        );
+    }
+
+    function testHashOriginTransition() external {
+        bytes32 actualHash = MetaBlock.hashOriginTransition(
+            uint256(1337),
+            bytes32(hex"24739574832097584935602afcbdef65498750164935602afcbdef6549875012"),
+            bytes20(hex"84739574832097584935602afcbdef6549875016")
+        );
+
+        Assert.equal(
+            actualHash,
+            hex"39caef53c03cdbe3db387ae0a60efd5bd01985a7ca3edeedabf66a6be3ce8ff8",
+            ""
+        );
+    }
+}

--- a/test/test_lib/meta_block.js
+++ b/test/test_lib/meta_block.js
@@ -20,14 +20,52 @@
 
 const web3 = require('./web3.js');
 
+const AUXILIARYTRANSITION_TYPEHASH = web3.utils.sha3(
+    'AuxiliaryTransition(bytes20 coreIdentifier,bytes32 kernelHash,uint256 auxiliaryDynasty,bytes32 auxiliaryBlockHash,uint256 gas,uint256 originDynasty,bytes32 originBlockHash,bytes32 transactionRoot)',
+);
+
 const ORIGINTRANSITION_TYPEHASH = web3.utils.sha3(
-    "OriginTransition(uint256 dynasty,bytes32 blockHash,bytes20 coreIdentifier)"
+    'OriginTransition(uint256 dynasty,bytes32 blockHash,bytes20 coreIdentifier)',
 );
 
 /**
- * 
  * @param {Object} transition The transition object to hash.
- * 
+ *
+ * @returns {string} The hash of the transition.
+ */
+module.exports.hashAuxiliaryTransition = function(transition) {
+    let encodedParameters = web3.eth.abi.encodeParameters(
+        [
+            'bytes32',
+            'bytes20',
+            'bytes32',
+            'uint256',
+            'bytes32',
+            'uint256',
+            'uint256',
+            'bytes32',
+            'bytes32',
+        ],
+        [
+            AUXILIARYTRANSITION_TYPEHASH,
+            transition.coreIdentifier,
+            transition.kernelHash,
+            transition.auxiliaryDynasty.toString(),
+            transition.auxiliaryBlockHash,
+            transition.gas.toString(),
+            transition.originDynasty.toString(),
+            transition.originBlockHash,
+            transition.transactionRoot,
+        ],
+    );
+    let hash = web3.utils.sha3(encodedParameters);
+
+    return hash;
+}
+
+/**
+ * @param {Object} transition The transition object to hash.
+ *
  * @returns {string} The hash of the transition.
  */
 module.exports.hashOriginTransition = function(transition) {
@@ -42,7 +80,7 @@ module.exports.hashOriginTransition = function(transition) {
             ORIGINTRANSITION_TYPEHASH,
             transition.dynasty.toString(),
             transition.blockHash,
-            transition.coreIdentifier
+            transition.coreIdentifier,
         ]
     );
     let hash = web3.utils.sha3(encodedParameters);


### PR DESCRIPTION
The auxiliary transition object was not used anywhere in the code. It is
now used wherever we need the auxiliary transition object. Mostly the
auxiliary block store.

In order to be able to calculate the transition object and hash at an
auxiliary checkpoint, we need to know the origin dynasty and latest
finalized block hash. Those two fields are now tracked on the auxiliary
block store per reponted block by calling on the origin block store. The
address of the origin block store was added to the constructor.

To decide whether a vote is valid, the auxiliary block store now
verifies the given transition hash against the hash that it calculates
itself based on the data that is available  at the source checkpoint. To
do that, `isValidTransitionHash` has been made internal on the
`BlockStore` and is overridden by the `AuxiliaryBlockStore`.

Added `getHead()` and `getCurrentDynasty()` to the `BlockStoreInterface`
and `BlockStore` and `BlockStoreMock`. The auxiliary block store uses
these functions to get the latest observations of the origin block store
when it stores a block report.

I updated the auxiliary block store tests to check for the corret
transition hash. Furthermore I added the accumulated values to the
shared data object.

I added solidity tests for the `MetaBlock` library.

All core identifier types were changed to `bytes20` which is the current
implementation. Must be changed to `bytes32` across the whole project
coordinated.

I tried caching only the transition hash per reported block in the
auxiliary block store instead of all the individual data points like
accumulated gas and accumulated transaction root. It turned out
impossible to do, as the dynasty of a block can change when an earlier
block gets finalized. Thus, the transition hash cannot be cached at the
time of a block report.

Fixes #336