### PR TITLE
Validators should be able to verify a vote

### DIFF
--- a/contracts/core/OriginCoreInterface.sol
+++ b/contracts/core/OriginCoreInterface.sol
@@ -63,8 +63,7 @@ interface OriginCoreInterface {
      * @dev Must track which votes have already been verified so that the same
      *      vote never gets verified more than once.
      *
-     * @param _metaBlockHash The block hash of the meta-block for which the
-     *                       votes shall be verified.
+     * @param _kernelHash The hash of the current kernel.
      * @param _coreIdentifier A unique identifier that identifies what chain
      *                        this vote is about.
      * @param _transition The hash of the transition part of the meta-block
@@ -80,7 +79,7 @@ interface OriginCoreInterface {
      * @return `true` if the verification succeeded.
      */
     function verifyVote(
-        bytes32 _metaBlockHash,
+        bytes32 _kernelHash,
         bytes20 _coreIdentifier,
         bytes32 _transition,
         bytes32 _source,

--- a/contracts/core/PollingPlace.sol
+++ b/contracts/core/PollingPlace.sol
@@ -15,6 +15,7 @@ pragma solidity ^0.4.23;
 // limitations under the License.
 
 import "../lib/SafeMath.sol";
+import "../lib/MetaBlock.sol";
 import "./BlockStoreInterface.sol";
 import "./PollingPlaceInterface.sol";
 
@@ -115,11 +116,6 @@ contract PollingPlace is PollingPlaceInterface {
         /** s component of signature */
         bytes32 s;
     }
-
-    /** To hash vote message according to EIP-712, a type hash is required. */
-    bytes32 constant VOTE_MESSAGE_TYPEHASH = keccak256(
-        "VoteMessage(bytes20 coreIdentifier,bytes32 transitionHash,bytes32 source,bytes32 target,uint256 sourceHeight,uint256 targetHeight)"
-    );
 
     /* Public Variables */
 
@@ -635,16 +631,13 @@ contract PollingPlace is PollingPlaceInterface {
         pure
         returns (bytes32 hashed_)
     {
-        hashed_ = keccak256(
-            abi.encodePacked(
-                VOTE_MESSAGE_TYPEHASH,
-                _voteMessage.coreIdentifier,
-                _voteMessage.transitionHash,
-                _voteMessage.source,
-                _voteMessage.target,
-                _voteMessage.sourceHeight,
-                _voteMessage.targetHeight
-            )
+        hashed_ = MetaBlock.hashVote(
+            _voteMessage.coreIdentifier,
+            _voteMessage.transitionHash,
+            _voteMessage.source,
+            _voteMessage.target,
+            _voteMessage.sourceHeight,
+            _voteMessage.targetHeight
         );
 
         // As per https://github.com/ethereum/go-ethereum/pull/2940

--- a/contracts/lib/MetaBlock.sol
+++ b/contracts/lib/MetaBlock.sol
@@ -22,6 +22,11 @@ library MetaBlock {
     bytes32 constant ORIGINTRANSITION_TYPEHASH = keccak256(
         "OriginTransition(uint256 dynasty,bytes32 blockHash,bytes20 coreIdentifier)"
     );
+    /** To hash vote message according to EIP-712, a type hash is required. */
+    bytes32 constant VOTE_MESSAGE_TYPEHASH = keccak256(
+        "VoteMessage(bytes20 coreIdentifier,bytes32 transitionHash,bytes32 source,bytes32 target,uint256 sourceHeight,uint256 targetHeight)"
+    );
+
 
     /* Structs */
 
@@ -213,4 +218,44 @@ library MetaBlock {
             )
         );
     }
+
+    /**
+     * @notice Creates the hash of vote.
+     *
+     * @param _coreIdentifier A unique identifier that identifies what chain
+     *                        this vote is about.
+     * @param _transition The hash of the transition part of the meta-block
+     *                    header at the source block.
+     * @param _source The hash of the source block.
+     * @param _target The hash of the target block.
+     * @param _sourceHeight The height of the source block.
+     * @param _targetHeight The height of the target block.
+     *
+     * @return The hash of the given vote.
+     */
+    function hashVote(
+        bytes20 _coreIdentifier,
+        bytes32 _transition,
+        bytes32 _source,
+        bytes32 _target,
+        uint256 _sourceHeight,
+        uint256 _targetHeight
+    )
+        internal
+        pure
+        returns (bytes32 hashed_)
+    {
+        hashed_ = keccak256(
+            abi.encodePacked(
+                VOTE_MESSAGE_TYPEHASH,
+                _coreIdentifier,
+                _transition,
+                _source,
+                _target,
+                _sourceHeight,
+                _targetHeight
+            )
+        );
+    }
+
 }

--- a/contracts/lib/MetaBlock.sol
+++ b/contracts/lib/MetaBlock.sol
@@ -125,6 +125,19 @@ library MetaBlock {
          */
         bytes20 coreIdentifier;
     }
+    /**
+     * Seal object which tracks vote of validators for an given transition hash.
+     */
+    struct Seal {
+        /**
+         * Mapping of validator address and boolean which represents all the
+         * validators who has voted for given transition object.
+         */
+        mapping(address => bool) validators;
+
+        /** Sum of all vote weight. */
+        uint256 totalVoteWeight;
+    }
 
     /**
      * @notice Takes the parameters of an transition object and returns the

--- a/contracts/lib/MetaBlock.sol
+++ b/contracts/lib/MetaBlock.sol
@@ -126,7 +126,7 @@ library MetaBlock {
         bytes20 coreIdentifier;
     }
     /**
-     * Seal object which tracks vote of validators for an given transition hash.
+     * Seal object which tracks vote of validators for a given transition hash.
      */
     struct Seal {
         /**

--- a/test/core/PollingPlace.js
+++ b/test/core/PollingPlace.js
@@ -24,6 +24,7 @@ const web3 = require('../test_lib/web3.js');
 const BN = require('bn.js');
 const EventsDecoder = require('../test_lib/event_decoder.js');
 const Utils = require('../test_lib/utils.js');
+const CoreUtils = require('./utils.js');
 
 const BlockStoreMock = artifacts.require('BlockStoreMock');
 const PollingPlace = artifacts.require('PollingPlace');
@@ -34,9 +35,6 @@ const ValidatorIndexEnded = 2;
 const ValidatorIndexStartHeight = 3;
 const ValidatorIndexEndHeight = 4;
 
-const VOTE_MESSAGE_TYPEHASH = web3.utils.sha3(
-  "VoteMessage(bytes20 coreIdentifier,bytes32 transitionHash,bytes32 source,bytes32 target,uint256 sourceHeight,uint256 targetHeight)"
-);
 
 contract('PollingPlace', async (accounts) => {
     /*
@@ -396,7 +394,7 @@ contract('PollingPlace', async (accounts) => {
 
         it('should accept a valid vote', async () => {
 
-            let signature = await signVote(accounts[0], vote);
+            let signature = await CoreUtils.signVote(accounts[0], vote);
 
             let pollingPlace = await PollingPlace.new(
                 metaBlockGate,
@@ -424,7 +422,7 @@ contract('PollingPlace', async (accounts) => {
         it('should not accept a vote signed by an unknown validator', async () => {
 
             // Signing for accounts[1], but adding accounts[0] as validator.
-            let signature = await signVote(accounts[1], vote);
+            let signature = await CoreUtils.signVote(accounts[1], vote);
 
             let pollingPlace = await PollingPlace.new(
                 metaBlockGate,
@@ -455,7 +453,7 @@ contract('PollingPlace', async (accounts) => {
             let unknownCoreIdentifier = '0x1234500000000000000000000000000000000001';
             vote.coreIdentifier = unknownCoreIdentifier;
 
-            let signature = await signVote(accounts[0], vote);
+            let signature = await CoreUtils.signVote(accounts[0], vote);
 
             let pollingPlace = await PollingPlace.new(
                 metaBlockGate,
@@ -486,7 +484,7 @@ contract('PollingPlace', async (accounts) => {
             // Target height is less than source height.
             vote.targetHeight = new BN('0');
 
-            let signature = await signVote(accounts[0], vote);
+            let signature = await CoreUtils.signVote(accounts[0], vote);
 
             let pollingPlace = await PollingPlace.new(
                 metaBlockGate,
@@ -529,7 +527,7 @@ contract('PollingPlace', async (accounts) => {
 
             // Origin block store should pass.
             vote.coreIdentifier = originCoreIdentifier;
-            let signature = await signVote(accounts[0], vote);
+            let signature = await CoreUtils.signVote(accounts[0], vote);
             await pollingPlace.vote(
                 vote.coreIdentifier,
                 vote.transitionHash,
@@ -544,7 +542,7 @@ contract('PollingPlace', async (accounts) => {
 
             // Auxiliary block store should fail.
             vote.coreIdentifier = auxiliaryCoreIdentifier;
-            signature = await signVote(accounts[0], vote);
+            signature = await CoreUtils.signVote(accounts[0], vote);
             await Utils.expectRevert(
                 pollingPlace.vote(
                     vote.coreIdentifier,
@@ -607,7 +605,7 @@ contract('PollingPlace', async (accounts) => {
              * for the first 7 there should not be a justification event.
              */
             for (var i = 0; i < 7; i++) {
-                let signature = await signVote(expectedWeights.addresses[i], vote);
+                let signature = await CoreUtils.signVote(expectedWeights.addresses[i], vote);
                 let tx = await pollingPlace.vote(
                     vote.coreIdentifier,
                     vote.transitionHash,
@@ -638,7 +636,7 @@ contract('PollingPlace', async (accounts) => {
              * The eighth vote sohuld trigger the expected event as a 2/3
              * majority is reached
              */
-            let signature = await signVote(expectedWeights.addresses[7], vote);
+            let signature = await CoreUtils.signVote(expectedWeights.addresses[7], vote);
             let tx = await pollingPlace.vote(
                 vote.coreIdentifier,
                 vote.transitionHash,
@@ -726,7 +724,7 @@ contract('PollingPlace', async (accounts) => {
                 let coreIdentifier = coreIdentifiers[i % 2];
                 vote.coreIdentifier = coreIdentifier;
 
-                let signature = await signVote(expectedWeights.addresses[i], vote);
+                let signature = await CoreUtils.signVote(expectedWeights.addresses[i], vote);
                 let tx = await pollingPlace.vote(
                     vote.coreIdentifier,
                     vote.transitionHash,
@@ -800,7 +798,7 @@ contract('PollingPlace', async (accounts) => {
                 // Incrementing source hashes to split the votes
                 vote.source = '0xe03b82d609dd4c84cdf0e94796d21d65f56b197405f983e593ac4302d38a112' + i.toString(16);
 
-                let signature = await signVote(expectedWeights.addresses[i], vote);
+                let signature = await CoreUtils.signVote(expectedWeights.addresses[i], vote);
                 let tx = await pollingPlace.vote(
                     vote.coreIdentifier,
                     vote.transitionHash,
@@ -835,7 +833,7 @@ contract('PollingPlace', async (accounts) => {
                 // Incrementing target hashes to split the votes
                 vote.target = '0x4bd8f94ba769f24bf30c09d4a3575795a776f76ca6f772893618943ea2dab9c' + i.toString(16);
 
-                let signature = await signVote(expectedWeights.addresses[i], vote);
+                let signature = await CoreUtils.signVote(expectedWeights.addresses[i], vote);
                 let tx = await pollingPlace.vote(
                     vote.coreIdentifier,
                     vote.transitionHash,
@@ -910,7 +908,7 @@ contract('PollingPlace', async (accounts) => {
             // The first 8 validators will validate 40 of 61 weight.
             for (var i = 0; i < 8; i++) {
 
-                let signature = await signVote(expectedWeights.addresses[i], vote);
+                let signature = await CoreUtils.signVote(expectedWeights.addresses[i], vote);
                 let tx = await pollingPlace.vote(
                     vote.coreIdentifier,
                     vote.transitionHash,
@@ -966,7 +964,7 @@ contract('PollingPlace', async (accounts) => {
              */
             vote.sourceHeight = new BN('5');
             vote.targetHeight = new BN('15');
-            let signature = await signVote(accounts[0], vote);
+            let signature = await CoreUtils.signVote(accounts[0], vote);
             await pollingPlace.vote(
                 vote.coreIdentifier,
                 vote.transitionHash,
@@ -981,7 +979,7 @@ contract('PollingPlace', async (accounts) => {
 
             // Even with a different source.
             vote.sourceHeight = new BN('8');
-            signature = await signVote(accounts[0], vote);
+            signature = await CoreUtils.signVote(accounts[0], vote);
             await Utils.expectRevert(
                 pollingPlace.vote(
                     vote.coreIdentifier,
@@ -1016,7 +1014,7 @@ contract('PollingPlace', async (accounts) => {
             );
 
             vote.targetHeight = new BN('19891109');
-            let signature = await signVote(accounts[0], vote);
+            let signature = await CoreUtils.signVote(accounts[0], vote);
 
             await pollingPlace.vote(
                 vote.coreIdentifier,
@@ -1050,7 +1048,7 @@ contract('PollingPlace', async (accounts) => {
             );
 
             vote.targetHeight = new BN('19851209');
-            let signature = await signVote(accounts[0], vote);
+            let signature = await CoreUtils.signVote(accounts[0], vote);
 
             await Utils.expectRevert(
                 pollingPlace.vote(
@@ -1068,46 +1066,5 @@ contract('PollingPlace', async (accounts) => {
         });
 
     });
-
-    /**
-     * @param {string} address The address of the account that signs the vote.
-     * @param {Object} vote The vote object to sign.
-     * @returns {Object} The signature of the vote (r, s, and v).
-     */
-    async function signVote(address, vote) {
-
-        let voteDigest = web3.utils.soliditySha3(
-            {type: 'bytes32', value: VOTE_MESSAGE_TYPEHASH},
-            {type: 'bytes20', value: web3.utils.toChecksumAddress(vote.coreIdentifier)},
-            {type: 'bytes32', value: vote.transitionHash},
-            {type: 'bytes32', value: vote.source},
-            {type: 'bytes32', value: vote.target},
-            {type: 'uint256', value: vote.sourceHeight},
-            {type: 'uint256', value: vote.targetHeight},
-        );
-
-        /*
-         * Signature adds the prefix `\x19Ethereum Signed Message:\n32` to the
-         * voteDigest.
-         */
-        let signature = await web3.eth.sign(
-            voteDigest,
-            address
-        );
-
-        // Removing the `0x` prefix.
-        signature = signature.substring(2);
-
-        let r = '0x' + signature.substring(0, 64);
-        let s = '0x' + signature.substring(64, 128);
-        // Adding 27 as per the web3 documentation.
-        let v = Number(signature.substring(128, 130)) + 27;
-
-        return {
-            r: r,
-            s: s,
-            v: v,
-        };
-    }
 
 });

--- a/test/core/origin_core/verify_vote.js
+++ b/test/core/origin_core/verify_vote.js
@@ -25,29 +25,106 @@ const BN = require('bn.js');
 const EventsDecoder = require('../../test_lib/event_decoder.js');
 const Utils = require('../../test_lib/utils.js');
 const CoreUtils = require('../utils.js');
+const StakeUtils = require('../stake/helpers/stake_utils.js');
+
 
 const OriginCore = artifacts.require('OriginCore');
+const Stake = artifacts.require('Stake');
+const MockToken = artifacts.require('MockToken');
+
+async function verifyVote(stakeAmount, validator, vote, originCore, kernelHash, expectedTotalWeight) {
+
+    validator = web3.utils.toChecksumAddress(validator);
+
+    let sig = await CoreUtils.signVote(validator, vote);
+
+    let tx = await originCore.verifyVote(
+         kernelHash,
+         vote.coreIdentifier,
+         vote.transitionHash,
+         vote.source,
+         vote.target,
+         vote.sourceHeight,
+         vote.targetHeight,
+         sig.v,
+         sig.r,
+         sig.s
+    );
+
+    let events = EventsDecoder.perform(tx.receipt, originCore.address, originCore.abi);
+
+    assert.equal(
+         web3.utils.toChecksumAddress(events.VoteVerified.validator),
+         validator,
+         `Verify event should recover validator signature`
+    );
+
+    assert(
+         expectedTotalWeight.eq(new BN(events.VoteVerified.totalWeight)),
+         `expected total weight ${expectedTotalWeight.toString(10)}` +
+         `and actual total weight ${events.VoteVerified.totalWeight.toString(10)}`
+    );
+
+}
 
 contract('OriginCore.verifyVote()', async (accounts) => {
 
-    let originCore;
+    let originCore, stake;
     let transitionHash;
     let vote;
     let minimumWeight = new BN('1');
-    let ost = accounts[0];
+    let ost;
     let initialGas = 0;
     let transactionRoot = web3.utils.sha3("1");
     let auxiliaryCoreIdentifier = web3.utils.sha3("1");
     let kernelHash = web3.utils.sha3("1");
+    let initialValidators;
+    let initialDepositors;
+    let initialStakes;
 
     beforeEach(async () => {
 
+        let tokenDeployer = accounts[0];
+        ost = await MockToken.new({from: tokenDeployer});
+
         originCore = await OriginCore.new(
              auxiliaryCoreIdentifier,
-             ost,
+             ost.address,
              initialGas,
              transactionRoot,
              minimumWeight
+        );
+        let stakeAddress = await originCore.stake.call();
+
+        stake = await Stake.at(stakeAddress);
+
+        initialDepositors = [
+            accounts[2],
+            accounts[3],
+            accounts[4],
+        ];
+        initialValidators = [
+            accounts[5],
+            accounts[6],
+            accounts[7],
+        ];
+        initialStakes = [
+            new BN('100'),
+            new BN('2000'),
+            new BN('30000'),
+        ];
+
+        await StakeUtils.approveTransfers(
+             stakeAddress,
+             ost,
+             tokenDeployer,
+             initialDepositors,
+             initialStakes,
+        );
+        await stake.initialize(
+             initialDepositors,
+             initialValidators,
+             initialStakes,
         );
 
         let height = 1,
@@ -89,31 +166,177 @@ contract('OriginCore.verifyVote()', async (accounts) => {
 
     it('should be able to verify vote for proposed meta-block', async function () {
 
+        let expectedTotalWeight = new BN(initialStakes[0]);
+        await verifyVote(
+             initialStakes[0],
+             initialValidators[0],
+             vote,
+             originCore,
+             kernelHash,
+             expectedTotalWeight
+        );
+
+    });
+
+    it('should not be able to verify already verified vote.', async function () {
+
+        let validator = initialValidators[0];
+
+        let sig = await CoreUtils.signVote(validator, vote);
+
+        let expectedTotalWeight = new BN(initialStakes[0]);
+        await verifyVote(
+             initialStakes[0],
+             validator,
+             vote,
+             originCore,
+             kernelHash,
+             expectedTotalWeight
+        );
+
+        await Utils.expectThrow(
+             originCore.verifyVote(
+                  kernelHash,
+                  vote.coreIdentifier,
+                  vote.transitionHash,
+                  vote.source,
+                  vote.target,
+                  vote.sourceHeight,
+                  vote.targetHeight,
+                  sig.v,
+                  sig.r,
+                  sig.s
+             ),
+             `Vote already verified for this validator.`
+        );
+
+    });
+
+    it('should not verify vote for validator with zero weight.', async function () {
+
         let validator = web3.utils.toChecksumAddress(accounts[0]);
 
         let sig = await CoreUtils.signVote(validator, vote);
 
-        let tx = await originCore.verifyVote(
+        await Utils.expectThrow(
+             originCore.verifyVote(
+                  kernelHash,
+                  vote.coreIdentifier,
+                  vote.transitionHash,
+                  vote.source,
+                  vote.target,
+                  vote.sourceHeight,
+                  vote.targetHeight,
+                  sig.v,
+                  sig.r,
+                  sig.s
+             ),
+             `Only validator with non zero weight can vote.`
+        );
+
+    });
+
+    it('should increase total weight on successful verification of vote', async function () {
+
+        let expectedTotalWeight = new BN(initialStakes[0]);
+
+        await verifyVote(
+             initialStakes[0],
+             initialValidators[0],
+             vote,
+             originCore,
              kernelHash,
-             vote.coreIdentifier,
-             vote.transitionHash,
-             vote.source,
-             vote.target,
-             vote.sourceHeight,
-             vote.targetHeight,
-             sig.v,
-             sig.r,
-             sig.s
-            );
+             expectedTotalWeight
+        );
 
-        let events = EventsDecoder.perform(tx.receipt, originCore.address, originCore.abi);
+        expectedTotalWeight = expectedTotalWeight.add(new BN(initialStakes[1]));
 
-        assert.equal(
-             web3.utils.toChecksumAddress(events.VoteVerified.validator),
-             validator,
-             `Verify event should recover validator signature`
+        await verifyVote(
+             initialStakes[1],
+             initialValidators[1],
+             vote,
+             originCore,
+             kernelHash,
+             expectedTotalWeight
         );
     });
 
+    it('should not verify vote for validator with wrong signature', async function () {
+
+        let sig = {
+            v: 28,
+            r: web3.utils.sha3("invalid r"),
+            s: web3.utils.sha3("invalid s")
+        };
+
+        await Utils.expectThrow(
+             originCore.verifyVote(
+                  kernelHash,
+                  vote.coreIdentifier,
+                  vote.transitionHash,
+                  vote.source,
+                  vote.target,
+                  vote.sourceHeight,
+                  vote.targetHeight,
+                  sig.v,
+                  sig.r,
+                  sig.s
+             ),
+             `Only validator with non zero weight can vote.`
+        );
+
+    });
+
+    it('should not verify vote for transition hash which is not proposed', async function () {
+
+        let validator = initialValidators[0];
+
+        let sig = await CoreUtils.signVote(validator, vote);
+
+        let wrongTransitionHash = web3.utils.sha3("wrong transition hash");
+
+        await Utils.expectThrow(
+             originCore.verifyVote(
+                  kernelHash,
+                  vote.coreIdentifier,
+                  wrongTransitionHash,
+                  vote.source,
+                  vote.target,
+                  vote.sourceHeight,
+                  vote.targetHeight,
+                  sig.v,
+                  sig.r,
+                  sig.s
+             ),
+             `Given transition object is not proposed for given kernel.`
+        );
+    });
+
+    it('should not verify vote for invalid kernel hash ', async function () {
+
+        let validator = initialValidators[0];
+
+        let sig = await CoreUtils.signVote(validator, vote);
+
+        kernelHash = web3.utils.sha3("wrong kernel hash");
+
+        await Utils.expectThrow(
+             originCore.verifyVote(
+                  kernelHash,
+                  vote.coreIdentifier,
+                  vote.transitionHash,
+                  vote.source,
+                  vote.target,
+                  vote.sourceHeight,
+                  vote.targetHeight,
+                  sig.v,
+                  sig.r,
+                  sig.s
+             ),
+             `Given transition object is not proposed for given kernel.`
+        );
+    });
 });
+
+
 

--- a/test/core/origin_core/verify_vote.js
+++ b/test/core/origin_core/verify_vote.js
@@ -59,6 +59,36 @@ async function verifyVote(stakeAmount, validator, vote, originCore, kernelHash, 
          `Verify event should recover validator signature`
     );
 
+    assert.equal(
+         events.VoteVerified.kernelHash,
+         kernelHash,
+         `Kernel hash should match`
+    );
+
+    assert.equal(
+         events.VoteVerified.transitionHash,
+         vote.transitionHash,
+         `transitionHash hash should match`
+    );
+
+    assert.equal(
+         events.VoteVerified.v,
+         sig.v,
+         `V of signature should match`
+    );
+
+    assert.equal(
+         events.VoteVerified.r,
+         sig.r,
+         `R of signature should match`
+    );
+
+    assert.equal(
+         events.VoteVerified.s,
+         sig.s,
+         `S of signature should match`
+    );
+
     assert(
          expectedTotalWeight.eq(new BN(events.VoteVerified.totalWeight)),
          `expected total weight ${expectedTotalWeight.toString(10)}` +

--- a/test/core/origin_core/verify_vote.js
+++ b/test/core/origin_core/verify_vote.js
@@ -1,0 +1,119 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+// Test: verfiy_vote.js
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const web3 = require('../../test_lib/web3.js');
+
+const BN = require('bn.js');
+const EventsDecoder = require('../../test_lib/event_decoder.js');
+const Utils = require('../../test_lib/utils.js');
+const CoreUtils = require('../utils.js');
+
+const OriginCore = artifacts.require('OriginCore');
+
+contract('OriginCore.verifyVote()', async (accounts) => {
+
+    let originCore;
+    let transitionHash;
+    let vote;
+    let minimumWeight = new BN('1');
+    let ost = accounts[0];
+    let initialGas = 0;
+    let transactionRoot = web3.utils.sha3("1");
+    let auxiliaryCoreIdentifier = web3.utils.sha3("1");
+    let kernelHash = web3.utils.sha3("1");
+
+    beforeEach(async () => {
+
+        originCore = await OriginCore.new(
+             auxiliaryCoreIdentifier,
+             ost,
+             initialGas,
+             transactionRoot,
+             minimumWeight
+        );
+
+        let height = 1,
+             auxiliaryDynasty = 50,
+             auxiliaryBlockHash = web3.utils.sha3("1"),
+             gas = 1000,
+             originDynasty = 1,
+             originBlockHash = web3.utils.sha3("1");
+
+        let tx = await originCore.proposeBlock(
+             height,
+             auxiliaryCoreIdentifier,
+             kernelHash,
+             auxiliaryDynasty,
+             auxiliaryBlockHash,
+             gas,
+             originDynasty,
+             originBlockHash,
+             transactionRoot
+        );
+        let events = EventsDecoder.perform(tx.receipt, originCore.address, originCore.abi);
+
+        assert.equal(
+             events.BlockProposed.height,
+             height,
+             `Meta-block should be proposed for height ${height}`
+        );
+        transitionHash = events.BlockProposed.transitionHash;
+
+        vote = {
+            coreIdentifier: accounts[0],//auxiliaryCoreIdentifier,
+            transitionHash: transitionHash,
+            source: '0xe03b82d609dd4c84cdf0e94796d21d65f56b197405f983e593ac4302d38a112b',
+            target: '0x4bd8f94ba769f24bf30c09d4a3575795a776f76ca6f772893618943ea2dab9ce',
+            sourceHeight: new BN('1'),
+            targetHeight: new BN('2'),
+        };
+    });
+
+    it('should be able to verify vote for proposed meta-block', async function () {
+
+        let validator = web3.utils.toChecksumAddress(accounts[0]);
+
+        let sig = await CoreUtils.signVote(validator, vote);
+
+        let tx = await originCore.verifyVote(
+             kernelHash,
+             vote.coreIdentifier,
+             vote.transitionHash,
+             vote.source,
+             vote.target,
+             vote.sourceHeight,
+             vote.targetHeight,
+             sig.v,
+             sig.r,
+             sig.s
+            );
+
+        let events = EventsDecoder.perform(tx.receipt, originCore.address, originCore.abi);
+
+        assert.equal(
+             web3.utils.toChecksumAddress(events.VoteVerified.validator),
+             validator,
+             `Verify event should recover validator signature`
+        );
+    });
+
+});
+

--- a/test/core/utils.js
+++ b/test/core/utils.js
@@ -1,0 +1,75 @@
+// Copyright 2017 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+// Test: core/utils.js
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const web3 = require('../test_lib/web3.js');
+
+const VOTE_MESSAGE_TYPEHASH = web3.utils.sha3(
+     "VoteMessage(bytes20 coreIdentifier,bytes32 transitionHash,bytes32 source,bytes32 target,uint256 sourceHeight,uint256 targetHeight)"
+);
+
+function Utils() {
+
+}
+
+Utils.prototype = {
+    /**
+     * @param {string} address The address of the account that signs the vote.
+     * @param {Object} vote The vote object to sign.
+     * @returns {Object} The signature of the vote (r, s, and v).
+     */
+    signVote : async function (address, vote) {
+
+        let voteDigest = web3.utils.soliditySha3(
+             {type: 'bytes32', value: VOTE_MESSAGE_TYPEHASH},
+             {type: 'bytes20', value: web3.utils.toChecksumAddress(vote.coreIdentifier)},
+             {type: 'bytes32', value: vote.transitionHash},
+             {type: 'bytes32', value: vote.source},
+             {type: 'bytes32', value: vote.target},
+             {type: 'uint256', value: vote.sourceHeight},
+             {type: 'uint256', value: vote.targetHeight},
+        );
+
+        /*
+         * Signature adds the prefix `\x19Ethereum Signed Message:\n32` to the
+         * voteDigest.
+         */
+        let signature = await web3.eth.sign(
+             voteDigest,
+             address
+        );
+
+        // Removing the `0x` prefix.
+        signature = signature.substring(2);
+
+        let r = '0x' + signature.substring(0, 64);
+        let s = '0x' + signature.substring(64, 128);
+        // Adding 27 as per the web3 documentation.
+        let v = Number(signature.substring(128, 130)) + 27;
+
+        return {
+            r: r,
+            s: s,
+            v: v,
+        };
+    }
+};
+
+module.exports = new Utils();


### PR DESCRIPTION
This ticket implements the following features: 

1. Before vote verification: 
      1. Checks if meta-block proposal exists 
      2. Check validity of the signature 
      3. Check if validator can vote 
      4. Check if the vote is already verified (duplicate vote) 
  

2. Save vote and count towards the seal. 

Note: CoreIdentifier verification is not done with this story, It's part of #384 

#401 