### PR TITLE
Support zero gas price and gas limit in stake & redeem

### DIFF
--- a/contracts/gateway/EIP20CoGateway.sol
+++ b/contracts/gateway/EIP20CoGateway.sol
@@ -790,14 +790,6 @@ contract EIP20CoGateway is GatewayBase {
             "Mint amount must not be zero"
         );
         require(
-            _gasPrice != 0,
-            "Gas price must not be zero"
-        );
-        require(
-            _gasLimit != 0,
-            "Gas limit must not be zero"
-        );
-        require(
             _rlpParentNodes.length != 0,
             "RLP parent nodes must not be zero"
         );
@@ -915,15 +907,6 @@ contract EIP20CoGateway is GatewayBase {
             _facilitator != address(0),
             "Facilitator address must not be zero"
         );
-        require(
-            _gasPrice != 0,
-            "Gas price must not be zero"
-        );
-        require(
-            _gasLimit != 0,
-            "Gas limit must not be zero"
-        );
-
         // Get the redeem intent hash
         bytes32 intentHash = GatewayLib.hashRedeemIntent(
             _amount,

--- a/contracts/gateway/EIP20Gateway.sol
+++ b/contracts/gateway/EIP20Gateway.sol
@@ -295,14 +295,6 @@ contract EIP20Gateway is GatewayBase {
             "Staker address must not be zero"
         );
         require(
-            _gasPrice != 0,
-            "Gas price must not be zero"
-        );
-        require(
-            _gasLimit != 0,
-            "Gas limit must not be zero"
-        );
-        require(
             _signature.length == 65,
             "Signature must be of length 65"
         );
@@ -699,14 +691,6 @@ contract EIP20Gateway is GatewayBase {
         require(
             _amount != 0,
             "Redeem amount must not be zero"
-        );
-        require(
-            _gasPrice != 0,
-            "Gas price must not be zero"
-        );
-        require(
-            _gasLimit != 0,
-            "Gas limit must not be zero"
         );
         require(
             _rlpEncodedParentNodes.length > 0,

--- a/test/gateway/eip20_gateway/stake.js
+++ b/test/gateway/eip20_gateway/stake.js
@@ -176,19 +176,6 @@ contract('EIP20Gateway.stake() ', function (accounts) {
         await _stake(utils.ResultType.FAIL);
     });
 
-    it('should fail to stake when gas price is 0', async function () {
-        gasPrice = new BN(0);
-        errorMessage = "Gas price must not be zero";
-        await _stake(utils.ResultType.FAIL);
-    });
-
-    it('should fail to stake when gas limit is 0', async function () {
-        gasLimit = new BN(0);
-        errorMessage = "Gas limit must not be zero";
-        await _prepareData();
-        await _stake(utils.ResultType.FAIL);
-    });
-
     it('should fail to stake when signature is not of length 65 (invalid bytes)', async function () {
         await _prepareData();
         signature = accounts[9];


### PR DESCRIPTION
Please merge #512 before this. 

Stake and redeem now supports zero gas price and gas limit. 
Fixes #494 
Unit test cases for `redeem` will be done in #517 