### PR TITLE
Upadte package json version to 0.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "openst-protocol",
-  "version": "0.9.1",
+  "name": "mosaic-contracts",
+  "version": "0.9.4",
   "description": "",
   "devDependencies": {
     "abi-decoder": "1.2.0",


### PR DESCRIPTION
Fixes #565  

Upgraded package.json version to `0.9.4` and name to `mosaic-contracts`