### PR TITLE
Provides NPM package to access contracts' metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,13 +19,18 @@ package-lock.json
 # Do not track builds
 build/
 
-# Do not track intelliJ files
+# Do not track IDE files
 .idea/
+.vscode/
 *.iml
 
 # LaTeX auxiliary files
 *.aux
 *.log
+
+# NPM package generated files:
+dist/contracts.json
+
 ## Build tool auxiliary files:
 *.synctex
 *.synctex(busy)

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,6 @@ before_script:
 script:
   - npm run test
   - npm run test:deployment_tool
+  - npm run build-package
 after_script:
   - kill $(ps aux | grep 'ganache-cli' | awk '{print $2}')

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,4 @@
-// Copyright 2018 OpenST Ltd.
+// Copyright 2019 OpenST Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,3 +1,23 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
 const contracts = require('./contracts.json');
 
 module.exports = contracts;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,3 @@
+const contracts = require('./contracts.json');
+
+module.exports = contracts;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mosaic-contracts",
-  "version": "0.10.0-alpha",
+  "version": "0.10.0-alpha.0",
   "description": "Mosaic contracts provide ABIs and BINs for EVM smart contracts to run mosaic.",
   "devDependencies": {
     "abi-decoder": "1.2.0",
@@ -21,10 +21,12 @@
   },
   "scripts": {
     "compile": "truffle compile",
+    "compile-all": "truffle compile --all",
     "test": "truffle test",
     "test:deployment_tool": "mocha tools/deployment_tool/test",
     "ganache": "sh tools/runGanacheCli.sh",
-    "prepare": "truffle compile --all && tools/build_package.js"
+    "build-package": "node tools/build_package.js",
+    "prepare": "npm run compile-all && npm run build-package"
   },
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mosaic-contracts",
-  "version": "0.9.4",
-  "description": "",
+  "version": "0.10.0-alpha",
+  "description": "Mosaic contracts provide ABIs and BINs for EVM smart contracts to run mosaic.",
   "devDependencies": {
     "abi-decoder": "1.2.0",
     "assert": "1.4.1",
@@ -22,9 +22,14 @@
   "scripts": {
     "compile": "truffle compile",
     "test": "truffle test",
+    "test:deployment_tool": "mocha tools/deployment_tool/test",
     "ganache": "sh tools/runGanacheCli.sh",
-    "test:deployment_tool": "mocha tools/deployment_tool/test"
+    "prepare": "truffle compile --all && tools/build_package.js"
   },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "author": "OpenST Foundation Ltd.",
   "license": "Apache v2.0"
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,17 @@
   "name": "mosaic-contracts",
   "version": "0.10.0-alpha.0",
   "description": "Mosaic contracts provide ABIs and BINs for EVM smart contracts to run mosaic.",
+  "keywords": [
+    "ethereum",
+    "mosaic",
+    "gateway",
+    "anchor"
+  ],
+  "homepage": "https://openst.org/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OpenSTFoundation/mosaic-contracts"
+  },
   "devDependencies": {
     "abi-decoder": "1.2.0",
     "assert": "1.4.1",

--- a/tools/build_package.js
+++ b/tools/build_package.js
@@ -1,5 +1,25 @@
 #!/usr/bin/env node
 
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
 /*
  * This file runs as part of the npm packaging process.
  *

--- a/tools/build_package.js
+++ b/tools/build_package.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Copyright 2018 OpenST Ltd.
+// Copyright 2019 OpenST Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tools/build_package.js
+++ b/tools/build_package.js
@@ -20,8 +20,8 @@
 //
 // ----------------------------------------------------------------------------
 
-/*
- * This file runs as part of the npm packaging process.
+/**
+ * @file This file runs as part of the npm packaging process.
  *
  * It reads a set number of contracts from the truffle build directory and
  * extracts ABI and BIN of each contract. The extracted information is added to
@@ -56,12 +56,20 @@ const contractNames = [
 const contracts = {};
 
 contractNames.forEach((contract) => {
-    const contractFile = fs.readFileSync(
-        path.join(
-            __dirname,
-            `../build/contracts/${contract}.json`,
-        ),
+    const contractPath = path.join(
+        __dirname,
+        `../build/contracts/${contract}.json`,
     );
+
+    if (!fs.existsSync(contractPath)) {
+        throw new Error(
+            `Cannot read file ${contractPath}.`
+            + 'Truffle compile must be run before building the package.'
+            + 'That should be done automatically when running `npm publish`.',
+        );
+    }
+
+    const contractFile = fs.readFileSync(contractPath);
     const metaData = JSON.parse(contractFile);
 
     contracts[contract] = {};

--- a/tools/build_package.js
+++ b/tools/build_package.js
@@ -74,7 +74,10 @@ contractNames.forEach((contract) => {
 
     contracts[contract] = {};
     contracts[contract].abi = metaData.abi;
-    contracts[contract].bin = metaData.bytecode;
+
+    if (metaData.bytecode !== '0x') {
+        contracts[contract].bin = metaData.bytecode;
+    }
 });
 
 fs.writeFileSync('dist/contracts.json', JSON.stringify(contracts));

--- a/tools/build_package.js
+++ b/tools/build_package.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+/*
+ * This file runs as part of the npm packaging process.
+ *
+ * It reads a set number of contracts from the truffle build directory and
+ * extracts ABI and BIN of each contract. The extracted information is added to
+ * a new object that is finally serialized to disk. That JSON file will be
+ * exported by this package.
+ *
+ * To add a contract to the published package, add its name to array of contract
+ * names.
+ */
+
+const fs = require('fs');
+
+const contractNames = [
+    'Anchor',
+    'BytesLib',
+    'CircularBufferUint',
+    'CoGatewayUtilityTokenInterface',
+    'EIP20CoGateway',
+    'EIP20Gateway',
+    'EIP20Interface',
+    'EIP20Token',
+    'GatewayBase',
+    'GatewayLib',
+    'MerklePatriciaProof',
+    'MessageBus',
+    'Organization',
+    'OrganizationInterface',
+    'Organized',
+    'RLP',
+    'RLPEncode',
+    'SafeMath',
+    'SimpleStake',
+    'StateRootInterface',
+    'UtilityToken',
+    'UtilityTokenInterface',
+];
+
+const contracts = {};
+
+contractNames.forEach((contract) => {
+    const contractFile = fs.readFileSync(`build/contracts/${contract}.json`);
+    const metaData = JSON.parse(contractFile);
+
+    contracts[contract] = {};
+    contracts[contract].abi = metaData.abi;
+    contracts[contract].bin = metaData.bytecode;
+});
+
+fs.writeFileSync('dist/contracts.json', JSON.stringify(contracts));

--- a/tools/build_package.js
+++ b/tools/build_package.js
@@ -13,27 +13,21 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 
 const contractNames = [
     'Anchor',
-    'BytesLib',
-    'CircularBufferUint',
     'CoGatewayUtilityTokenInterface',
     'EIP20CoGateway',
     'EIP20Gateway',
     'EIP20Interface',
     'EIP20Token',
-    'GatewayBase',
     'GatewayLib',
     'MerklePatriciaProof',
     'MessageBus',
     'Organization',
     'OrganizationInterface',
     'Organized',
-    'RLP',
-    'RLPEncode',
-    'SafeMath',
-    'SimpleStake',
     'StateRootInterface',
     'UtilityToken',
     'UtilityTokenInterface',
@@ -42,7 +36,12 @@ const contractNames = [
 const contracts = {};
 
 contractNames.forEach((contract) => {
-    const contractFile = fs.readFileSync(`build/contracts/${contract}.json`);
+    const contractFile = fs.readFileSync(
+        path.join(
+            __dirname,
+            `../build/contracts/${contract}.json`,
+        ),
+    );
     const metaData = JSON.parse(contractFile);
 
     contracts[contract] = {};


### PR DESCRIPTION
`package.json`:
I added the entries `main` and `files` in order to specify the entry
point and which files should be part of the package. Only `dist` is
required, as it contains the `main` and the data in a JSON file.
I also added `scripts.prepare` which will be run by NPM as first action
when you run `npm publish`.
I set the versdion to `0.10.0-alpha`, as the current contents are not
`0.9.4` anymore.

I created a new script `tools/build_package.js`, which reads a specified
set of contracts from the truffle build directory and adds the ABIs and
BINs of the specified contracts to a single object, which is serialized
to `dist/contracts.json` and read by `dist/index.js`.

For now, `dist/index.js` only reads the JSON file and exports the
object.

I added the built JSON file to `.gitignore`. It will be automatically
built when running `npm publish`.

Output when packaging (note `Tarball Contents`):
```
npm publish --dry-run

npm notice
npm notice 📦  mosaic-contracts@0.10.0-alpha
npm notice === Tarball Contents ===
npm notice 969B    package.json
npm notice 11.9kB  CHANGELOG.md
npm notice 11.4kB  LICENSE
npm notice 3.2kB   README.md
npm notice 199.1kB dist/contracts.json
npm notice 76B     dist/index.js
npm notice === Tarball Details ===
npm notice name:          mosaic-contracts
npm notice version:       0.10.0-alpha
npm notice package size:  44.3 kB
npm notice unpacked size: 226.6 kB
npm notice shasum:        1ca7db737987ca698d968daa0b6f9142470b0300
npm notice integrity:     sha512-Eho/6JPAB9eh7[...]0LqUSgA4LCwwA==
npm notice total files:   6
npm notice
+ mosaic-contracts@0.10.0-alpha
```

I tested the package by creating a test project and installing the
package via `npm` by providing the absolute path.
I also tested `npm install -g .` and it works.

Fixes #615