### PR TITLE
[WIP] Integration tests can use deployed contracts

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,9 +3,18 @@
         "airbnb-base"
     ],
     "rules": {
-        "indent": ["error", 4],
+        "indent": [
+            "error",
+            4
+        ],
         "no-console": "off",
-        "no-underscore-dangle": "off"
+        "no-underscore-dangle": "off",
+        "import/no-extraneous-dependencies": [
+            "error",
+            {
+                "devDependencies": true
+            }
+        ]
     },
     "env": {
         "mocha": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "openst-protocol",
-  "version": "0.9.1",
+  "name": "mosaic-contracts",
+  "version": "0.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -198,7 +198,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -628,6 +628,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
     },
     "combined-stream": {
@@ -1627,7 +1633,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
           "dev": true
         }
@@ -1905,7 +1911,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -2230,6 +2236,15 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -4068,7 +4083,7 @@
       "dependencies": {
         "nan": {
           "version": "2.10.0",
-          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
           "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true
         }
@@ -4694,7 +4709,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -5267,6 +5282,53 @@
         "extsprintf": "^1.2.0"
       }
     },
+    "wait-port": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-0.2.2.tgz",
+      "integrity": "sha1-1RpJHkhKF791qUfnEaLwErTm8uM=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "commander": "^2.9.0",
+        "debug": "^2.6.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "web3": {
       "version": "1.0.0-beta.36",
       "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.36.tgz",
@@ -5426,7 +5488,7 @@
         },
         "uuid": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
           "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -7,23 +7,28 @@
     "assert": "1.4.1",
     "bn.js": "4.11.8",
     "chai": "4.2.0",
+    "colors": "1.3.3",
     "eslint": "5.10.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.14.0",
     "ganache-cli": "6.1.8",
+    "inquirer": "6.2.1",
     "keccak": "1.4.0",
     "mocha": "5.2.0",
     "rlp": "2.1.0",
     "solidity-coverage": "0.5.11",
     "solparse": "2.2.5",
     "truffle": "beta",
+    "wait-port": "^0.2.2",
     "web3": "1.0.0-beta.36"
   },
   "scripts": {
     "compile": "truffle compile",
     "test": "truffle test",
+    "test:integration": "cd test_integration && ./main.sh",
+    "test:deployment_tool": "mocha tools/deployment_tool/test",
     "ganache": "sh tools/runGanacheCli.sh",
-    "test:deployment_tool": "mocha tools/deployment_tool/test"
+    "deploy:gateway": "npm run compile && node tools/blue_deployment/scripts/step1_origin_contracts.js"
   },
   "author": "OpenST Foundation Ltd.",
   "license": "Apache v2.0"

--- a/test_integration/01_deployment/01_deploy.js
+++ b/test_integration/01_deployment/01_deploy.js
@@ -1,0 +1,143 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const chai = require('chai');
+const Web3 = require('web3');
+const docker = require('../docker');
+const shared = require('../shared');
+const {
+    tryDeployNewToken,
+    getChainInfo,
+    deployAnchorAndGateway,
+    deployAnchorAndCoGateway,
+} = require('../../tools/blue_deployment/step1');
+
+const { assert } = chai;
+
+describe('Deploy', async () => {
+    let rpcEndpointOrigin;
+    let web3Origin;
+    let accountsOrigin;
+    let rpcEndpointAuxiliary;
+    let web3Auxiliary;
+    let accountsAuxiliary;
+
+    before(async () => {
+        ({ rpcEndpointOrigin, rpcEndpointAuxiliary } = await docker());
+
+        web3Origin = new Web3(rpcEndpointOrigin);
+        web3Auxiliary = new Web3(rpcEndpointAuxiliary);
+        accountsOrigin = await web3Origin.eth.getAccounts();
+        accountsAuxiliary = await web3Auxiliary.eth.getAccounts();
+
+        shared.origin.web3 = web3Origin;
+        shared.auxiliary.web3 = web3Auxiliary;
+    });
+
+    after(async () => {
+        const networkId = '*';
+        const Gateway = shared.artifacts.Gateway.clone(networkId);
+        Gateway.setProvider(shared.origin.web3.currentProvider);
+        shared.origin.contracts.gateway = await Gateway.at(
+            shared.origin.addresses.EIP20Gateway,
+        );
+
+        const CoGateway = shared.artifacts.CoGateway.clone(networkId);
+        CoGateway.setProvider(shared.auxiliary.web3.currentProvider);
+        shared.auxiliary.contracts.coGateway = await CoGateway.at(
+            shared.auxiliary.addresses.EIP20CoGateway,
+        );
+
+        const AnchorOrigin = shared.artifacts.Anchor.clone(networkId);
+        AnchorOrigin.setProvider(shared.origin.web3.currentProvider);
+        shared.origin.contracts.anchor = await AnchorOrigin.at(
+            shared.origin.addresses.Anchor,
+        );
+
+        const AnchorAuxiliary = shared.artifacts.Anchor.clone(networkId);
+        AnchorAuxiliary.setProvider(shared.auxiliary.web3.currentProvider);
+        shared.auxiliary.contracts.anchor = await AnchorAuxiliary.at(
+            shared.auxiliary.addresses.Anchor,
+        );
+    });
+
+    let tokenAddressOrigin;
+    let baseTokenAddressOrigin;
+    it('correctly deploys token and base token on Origin', async () => {
+        const deployerAddressOrigin = accountsOrigin[0];
+
+        tokenAddressOrigin = await tryDeployNewToken(
+            rpcEndpointOrigin,
+            deployerAddressOrigin,
+            'new',
+        );
+        assert(
+            Web3.utils.isAddress(tokenAddressOrigin),
+            'Did not correctly deploy token on Origin.',
+        );
+
+        baseTokenAddressOrigin = await tryDeployNewToken(
+            rpcEndpointOrigin,
+            deployerAddressOrigin,
+            'new',
+        );
+        assert(
+            Web3.utils.isAddress(baseTokenAddressOrigin),
+            'Did not correctly deploy base token on Origin.',
+        );
+    });
+
+    it('correctly deploys Gateway and CoGateway', async () => {
+        const deployerAddressOrigin = accountsOrigin[0];
+        const deployerAddressAuxiliary = accountsAuxiliary[0];
+
+        const bountyOrigin = '100';
+        const bountyAuxiliary = '100';
+
+        const originInfo = await getChainInfo(rpcEndpointOrigin);
+        const auxiliaryInfo = await getChainInfo(rpcEndpointAuxiliary);
+
+        const originAddresses = await deployAnchorAndGateway(
+            rpcEndpointOrigin,
+            deployerAddressOrigin,
+            tokenAddressOrigin,
+            baseTokenAddressOrigin,
+            bountyOrigin,
+            auxiliaryInfo.chainId,
+            auxiliaryInfo.blockHeight,
+            auxiliaryInfo.stateRoot,
+        );
+
+        const gatewayAddressOrigin = originAddresses.EIP20Gateway;
+        const auxiliaryAddresses = await deployAnchorAndCoGateway(
+            rpcEndpointAuxiliary,
+            deployerAddressAuxiliary,
+            tokenAddressOrigin,
+            gatewayAddressOrigin,
+            bountyAuxiliary,
+            originInfo.chainId,
+            originInfo.blockHeight,
+            originInfo.stateRoot,
+        );
+
+        shared.origin.addresses = originAddresses;
+        shared.auxiliary.addresses = auxiliaryAddresses;
+    });
+});

--- a/test_integration/02_stake_and_mint/01_stake.js
+++ b/test_integration/02_stake_and_mint/01_stake.js
@@ -1,0 +1,28 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const shared = require('../shared');
+
+// Dummy to show that it can access the contracts.
+describe('Stake', async () => {
+    it('stakes', async () => {
+        console.log(shared.origin.contracts.gateway);
+    });
+});

--- a/test_integration/docker-compose.yml
+++ b/test_integration/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+
+  geth_node_origin:
+    image: augurproject/dev-node-geth:v1.8.18
+    ports:
+      - "8546:8545"
+
+  geth_node_auxiliary:
+    image: augurproject/dev-node-geth:v1.8.18
+    ports:
+      - "8547:8545"

--- a/test_integration/docker.js
+++ b/test_integration/docker.js
@@ -1,0 +1,40 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+const waitPort = require('wait-port');
+
+const originPort = 8546;
+const auxiliaryPort = 8547;
+
+const asyncSleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const docker = () => {
+    const waitForOriginNode = waitPort({ port: originPort, output: 'silent' });
+    const waitForAuxiliaryNode = waitPort({ port: auxiliaryPort, output: 'silent' });
+    return Promise.all([waitForOriginNode, waitForAuxiliaryNode]).then(
+        // even after the ports are available the nodes need a bit of time to get online
+        () => asyncSleep(5000),
+    ).then(() => ({
+        rpcEndpointOrigin: `http://localhost:${originPort}`,
+        rpcEndpointAuxiliary: `http://localhost:${auxiliaryPort}`,
+    }));
+};
+
+module.exports = docker;

--- a/test_integration/integration_tests.js
+++ b/test_integration/integration_tests.js
@@ -1,0 +1,62 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+/**
+ * @file Truffle's `artifacts.require()` won't be available inside the Mocha
+ * tests. Thus, we load them here and add them to the `shared` object.
+ */
+
+const Mocha = require('mocha');
+const shared = require('./shared');
+
+const Anchor = artifacts.require('Anchor');
+const Gateway = artifacts.require('EIP20Gateway');
+const CoGateway = artifacts.require('EIP20CoGateway');
+
+
+const setupArtifacts = () => {
+    shared.artifacts.Anchor = Anchor;
+    shared.artifacts.Gateway = Gateway;
+    shared.artifacts.CoGateway = CoGateway;
+};
+
+const runTests = (callback) => {
+    const mocha = new Mocha({
+        enableTimeouts: false,
+    });
+
+    Mocha.utils.lookupFiles(__dirname, ['js'], true)
+        .filter(
+            // Skipping this file so that artifacts are not loaded.
+            file => file.substr(-20) !== 'integration_tests.js',
+        )
+        .forEach((file) => {
+            mocha.addFile(file);
+        });
+
+    mocha.run((failures) => {
+        callback(failures);
+    });
+};
+
+module.exports = (callback) => {
+    setupArtifacts();
+    runTests(callback);
+};

--- a/test_integration/main.sh
+++ b/test_integration/main.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PROJECT_NAME='mosaic_integration_tests'
+LOGLEVEL='ERROR'
+
+docker-compose --project-name $PROJECT_NAME --log-level $LOGLEVEL up &
+truffle --network integration_origin exec integration_tests.js
+docker-compose --project-name $PROJECT_NAME --log-level $LOGLEVEL down

--- a/test_integration/shared.js
+++ b/test_integration/shared.js
@@ -1,0 +1,63 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ----------------------------------------------------------------------------
+//
+// http://www.simpletoken.org/
+//
+// ----------------------------------------------------------------------------
+
+/**
+ * @file `shared` exists so that integration tests can share data among each other.
+ *
+ * One example is the addresses of contracts that were deployed on the test
+ * environment.
+ *
+ * Due to node's caching behavior when loading modules, it always returns the
+ * same object for repeated calls to `require()`.
+ *
+ * It is important that every `require` is written exactly `shared`,
+ * case-sensitive!
+ */
+
+/**
+ * @typedef {Object} Chain
+ * @property {Web3} web3
+ * @property {string[]} addresses
+ * @property {Object[]} contracts
+ */
+
+/**
+ * @typedef {Object} Shared
+ * @property {Chain} origin The origin chain.
+ * @property {Chain} auxiliary The auxiliary chain.
+ * @property {Object[]} artifacts
+ */
+
+/**
+ * @returns {Shared} The shared object.
+ */
+module.exports = {
+    origin: {
+        web3: {},
+        addresses: [],
+        contracts: [],
+    },
+    auxiliary: {
+        web3: {},
+        addresses: [],
+        contracts: [],
+    },
+    artifacts: [],
+};

--- a/truffle.js
+++ b/truffle.js
@@ -1,38 +1,45 @@
 module.exports = {
-  networks: {
-    development: {
-      host: "localhost",
-      network_id: "*", // Match any network id
-      port: 8545,
-      gas: 12000000,
-      gasPrice: 0x01,
-    },
-    integration: {
-      host: "localhost",
-      network_id: "*",
-      port: 8546,
-      gas: 9000000,
-      gasPrice: 0x3B9ACA00,
-    },
-    coverage: {
-      host: "localhost",
-      network_id: "*",
-      port: 8555,         // <-- If you change this, also set the port option in .solcover.js.
-      gas: 0xfffffffffff, // <-- Use this high gas value 
-      gasPrice: 0x01,     // <-- Use this low gas price
-    },
-  },
-  compilers: {
-    solc: {
-      settings: {
-        optimizer: {
-          enabled: true,
-          // set to same number of runs as openst-platform
-          // so that integration tests on openst-protocol
-          // give accurate gas measurements
-          runs: 200,
+    networks: {
+        development: {
+            host: 'localhost',
+            network_id: '*', // Match any network id
+            port: 8545,
+            gas: 12000000,
+            gasPrice: 0x01,
         },
-      },
+        integration_origin: {
+            host: 'localhost',
+            network_id: '*',
+            port: 8546,
+            gas: 9000000,
+            gasPrice: 0x3B9ACA00,
+        },
+        integration_auxiliary: {
+            host: 'localhost',
+            network_id: '*',
+            port: 8547,
+            gas: 9000000,
+            gasPrice: 0x3B9ACA00,
+        },
+        coverage: {
+            host: 'localhost',
+            network_id: '*',
+            port: 8555, // <-- If you change this, also set the port option in .solcover.js.
+            gas: 0xfffffffffff, // <-- Use this high gas value
+            gasPrice: 0x01, // <-- Use this low gas price
+        },
     },
-  },
+    compilers: {
+        solc: {
+            settings: {
+                optimizer: {
+                    enabled: true,
+                    // set to same number of runs as openst-platform
+                    // so that integration tests on openst-protocol
+                    // give accurate gas measurements
+                    runs: 200,
+                },
+            },
+        },
+    },
 };


### PR DESCRIPTION
The main file is `test_integration/main.sh` as called from
`package.json`.

Docker compose spawns two instances of geth, one for origin and one for
auxiliary. It also tears them down after the tests.

In between the tests are run. `integration_tests.js` puts everything
together (truffle and mocha) and executes the tests in the integration
test directory.

Deployment is required to deploy the contracts and add them to the
`shared` module.

The `shared` module is an object that stores data across tests. For
example Web3 instances or TruffleContract instances.

Stake and mint is just an example.

As examples I added two Anchors and the two Gateways to this PR. Can be
extended as required.

I had to use `truffle exec` in order to have access to
`artifacts.require`.

References #608 