### PR TITLE
Bring logging for deployer CLI back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "mosaic-contracts",
-  "version": "0.9.4",
+  "name": "@openstfoundation/mosaic-contracts",
+  "version": "0.10.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tools/blue_deployment/index.js
+++ b/tools/blue_deployment/index.js
@@ -132,6 +132,7 @@ const getChainInfo = async (web3) => {
  * @param {string} blockHeightAuxiliary The block height at wich Anchor starts
  *                                      tracking Auxiliary.
  * @param {string} stateRootAuxiliary The state root at `blockHeightAuxiliary`.
+ * @param {bool} options.log Whether to log the progress of the deployment.
  *
  * @returns {Promise.<object>} A promise resolving to a mapping of contract
  *                             names to their deployed addresses.
@@ -145,6 +146,9 @@ const deployOrigin = async (
     chainIdAuxiliary,
     blockHeightAuxiliary,
     stateRootAuxiliary,
+    options = {
+        log: false,
+    },
 ) => {
     const startingNonce = await web3Origin.eth.getTransactionCount(deployerAddress);
 
@@ -193,6 +197,7 @@ const deployOrigin = async (
         new UnlockedWeb3Signer(web3Origin),
         web3Origin,
         deploymentObjects,
+        options,
     );
 };
 
@@ -211,6 +216,7 @@ const deployOrigin = async (
  * @param {string} blockHeightOrigin The block height at wich Anchor starts
  *                                      tracking Origin.
  * @param {string} stateRootOrigin The state root at `blockHeightOrigin`.
+ * @param {bool} options.log Whether to log the progress of the deployment.
  *
  * @returns {Promise.<object>} A promise resolving to a mapping of contract
  *                             names to their deployed addresses.
@@ -224,6 +230,9 @@ const deployAuxiliary = async (
     chainIdOrigin,
     blockHeightOrigin,
     stateRootOrigin,
+    options = {
+        log: false,
+    },
 ) => {
     const startingNonce = await web3Auxiliary.eth.getTransactionCount(deployerAddress);
 
@@ -279,6 +288,7 @@ const deployAuxiliary = async (
         new UnlockedWeb3Signer(web3Auxiliary),
         web3Auxiliary,
         deploymentObjects,
+        options,
     );
 };
 

--- a/tools/blue_deployment/scripts/step1_origin_contracts.js
+++ b/tools/blue_deployment/scripts/step1_origin_contracts.js
@@ -63,11 +63,11 @@ const main = async () => {
     const deployerAddressOrigin = await inquireDeployerAddressOrigin(web3Origin);
 
     let tokenAddressOrigin = await inquireEIP20TokenAddress(web3Origin);
-    tokenAddressOrigin = await deployedToken(web3Origin, deployerAddressOrigin, tokenAddressOrigin);
+    tokenAddressOrigin = await deployedToken(web3Origin, deployerAddressOrigin, tokenAddressOrigin, { log: true });
     checkAddressForCode(web3Origin, tokenAddressOrigin);
 
     let baseTokenAddressOrigin = await inquireEIP20BaseTokenAddress();
-    baseTokenAddressOrigin = await deployedToken(web3Origin, deployerAddressOrigin, baseTokenAddressOrigin);
+    baseTokenAddressOrigin = await deployedToken(web3Origin, deployerAddressOrigin, baseTokenAddressOrigin, { log: true });
     checkAddressForCode(web3Origin, baseTokenAddressOrigin);
 
     printSign('QUESTIONS AUXILIARY');
@@ -91,6 +91,7 @@ const main = async () => {
         auxiliaryInfo.chainId,
         auxiliaryInfo.blockHeight,
         auxiliaryInfo.stateRoot,
+        { log: true },
     );
 
     printSign('DEPLOYING AUXILIARY');
@@ -104,6 +105,7 @@ const main = async () => {
         originInfo.chainId,
         originInfo.blockHeight,
         originInfo.stateRoot,
+        { log: true },
     );
 };
 


### PR DESCRIPTION
I dropped the deployer logging in #550, but as we are doing Ropsten-UC1409 test runs again, and real chains can be slow, we need the insight back.