### PR TITLE
Rearrange deletion of structs in confirm revert stake intent and confirm revert redeem intent

### DIFF
--- a/contracts/gateway/EIP20CoGateway.sol
+++ b/contracts/gateway/EIP20CoGateway.sol
@@ -413,6 +413,15 @@ contract EIP20CoGateway is GatewayBase {
             "RLP parent nodes must not be zero."
         );
 
+        amount_ = mints[_messageHash].amount;
+
+        require(
+            amount_ > uint256(0),
+            "Mint amount must not be zero."
+        );
+
+        delete mints[_messageHash];
+
         MessageBus.Message storage message = messages[_messageHash];
         require(
             message.intentHash != bytes32(0),
@@ -435,20 +444,15 @@ contract EIP20CoGateway is GatewayBase {
             storageRoot
         );
 
-        Mint storage mint = mints[_messageHash];
-
         staker_ = message.sender;
         stakerNonce_ = message.nonce;
-        amount_ = mint.amount;
 
         emit RevertStakeIntentConfirmed(
             _messageHash,
             message.sender,
             message.nonce,
-            mint.amount
+            amount_
         );
-
-        delete mints[_messageHash];
     }
 
     /**

--- a/contracts/gateway/EIP20Gateway.sol
+++ b/contracts/gateway/EIP20Gateway.sol
@@ -974,6 +974,15 @@ contract EIP20Gateway is GatewayBase {
             "RLP parent nodes must not be zero."
         );
 
+        amount_ = unstakes[_messageHash].amount;
+
+        require(
+            amount_ > uint256(0),
+            "Unstake amount must not be zero."
+        );
+
+        delete unstakes[_messageHash];
+
         // Get the message object.
         MessageBus.Message storage message = messages[_messageHash];
         require(
@@ -999,7 +1008,6 @@ contract EIP20Gateway is GatewayBase {
 
         redeemer_ = message.sender;
         redeemerNonce_ = message.nonce;
-        amount_ = unstakes[_messageHash].amount;
 
         emit RevertRedeemIntentConfirmed(
             _messageHash,
@@ -1007,8 +1015,6 @@ contract EIP20Gateway is GatewayBase {
             redeemerNonce_,
             amount_
         );
-
-        delete unstakes[_messageHash];
     }
 
     /**

--- a/test/gateway/eip20_cogateway/confirm_revert_stake_intent.js
+++ b/test/gateway/eip20_cogateway/confirm_revert_stake_intent.js
@@ -205,7 +205,7 @@ contract('EIP20CoGateway.confirmRevertStakeIntent() ', (accounts) => {
         blockHeight,
         storageProof,
       ),
-      'Message on target must be Declared.',
+      'Mint amount must not be zero.',
     );
   });
 

--- a/test/gateway/eip20_gateway/confirm_revert_redeem_intent.js
+++ b/test/gateway/eip20_gateway/confirm_revert_redeem_intent.js
@@ -210,7 +210,7 @@ contract('EIP20Gateway.confirmRevertRedeemIntent()', (accounts) => {
         blockHeight,
         storageProof,
       ),
-      'Message on target must be Declared.',
+      'Unstake amount must not be zero.',
     );
   });
 


### PR DESCRIPTION
Fixes #662  partially

In order to follow best practices, any state change like deletion should happen before any external call. 

Though confirm revert stake intent and confirm revert redeem intent doesn't make any external call, its good practice to move state changeup in the method. 